### PR TITLE
chore: add wizard flag to frontend env example

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -6,7 +6,7 @@
 > - `[x]` = done
 
 ## 1. Configuração da Flag
-- [ ] Adicionar `VITE_ENABLE_WIZARD=false` em `frontend/.env.example` (e replicar em `.env.local` quando necessário)
+- [x] Adicionar `VITE_ENABLE_WIZARD=false` em `frontend/.env.example` (e replicar em `.env.local` quando necessário)
 - [ ] Documentar a flag em `frontend/README.md` explicando finalidade, uso e necessidade de reiniciar `npm run dev`
 - [ ] Garantir leitura segura da flag (normalização para booleano) nos arquivos que dependem dela
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables for the Vite frontend
+# Copy this file to .env.local to customize values locally.
+
+# Toggle the preflight analysis banner and workflow in the welcome screen
+VITE_ENABLE_PREFLIGHT=true
+
+# Toggle to enable the new wizard-based welcome experience
+VITE_ENABLE_WIZARD=false


### PR DESCRIPTION
## Summary
- add a frontend `.env.example` file documenting the preflight toggle
- include the new `VITE_ENABLE_WIZARD` flag in the example configuration
- update the implementation checklist to mark the feature flag entry as complete

## Testing
- not run (configuration-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cf43cf72048321a6ea62e51bf8eedd