### PR TITLE
Document wizard feature flag usage

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -7,7 +7,7 @@
 
 ## 1. Configuração da Flag
 - [x] Adicionar `VITE_ENABLE_WIZARD=false` em `frontend/.env.example` (e replicar em `.env.local` quando necessário)
-- [ ] Documentar a flag em `frontend/README.md` explicando finalidade, uso e necessidade de reiniciar `npm run dev`
+- [x] Documentar a flag em `frontend/README.md` explicando finalidade, uso e necessidade de reiniciar `npm run dev`
 - [ ] Garantir leitura segura da flag (normalização para booleano) nos arquivos que dependem dela
 
 ## 2. Preservação da UI Atual

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,14 @@
+# Frontend
+
+## Feature Flags
+
+### Wizard UI (`VITE_ENABLE_WIZARD`)
+
+A flag que controla a nova experiência de onboarding baseada em wizard na tela de boas-vindas.
+
+- **Finalidade:** habilitar o formulário guiado que substitui o formulário clássico somente quando desejado.
+- **Como ativar:** copie `frontend/.env.example` para `.env.local` (se ainda não existir) e defina `VITE_ENABLE_WIZARD=true`.
+- **Como desativar:** mantenha `VITE_ENABLE_WIZARD=false` para preservar a experiência atual.
+- **Reinicialização necessária:** após alterar o valor da flag, interrompa o servidor de desenvolvimento (`npm run dev`) e inicie-o novamente para que o Vite recarregue as variáveis de ambiente.
+
+> ℹ️ A flag permanece `false` por padrão para evitar que a nova UI seja exibida inesperadamente em ambientes que ainda não foram atualizados.


### PR DESCRIPTION
## Summary
- document how to enable and disable the wizard UI feature flag in the frontend README
- note the need to restart the Vite dev server after toggling the flag
- update the implementation checklist to mark the documentation task as complete

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf4b05924883218f4e2a3da75ac18f