### PR TITLE
feat: normalize wizard feature flag access

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -8,7 +8,7 @@
 ## 1. Configuração da Flag
 - [x] Adicionar `VITE_ENABLE_WIZARD=false` em `frontend/.env.example` (e replicar em `.env.local` quando necessário)
 - [x] Documentar a flag em `frontend/README.md` explicando finalidade, uso e necessidade de reiniciar `npm run dev`
-- [ ] Garantir leitura segura da flag (normalização para booleano) nos arquivos que dependem dela
+- [x] Garantir leitura segura da flag (normalização para booleano) nos arquivos que dependem dela
 
 ## 2. Preservação da UI Atual
 - [ ] Revisar e confirmar que `frontend/src/components/InputForm.tsx` permanece inalterado

--- a/frontend/src/components/WelcomeScreen.tsx
+++ b/frontend/src/components/WelcomeScreen.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { SectionCard } from "@/components/ui/section-card";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { InputForm } from "@/components/InputForm";
+import { isWizardEnabled } from "@/utils/featureFlags";
 
 interface WelcomeScreenProps {
   handleSubmit: (query: string) => void;
@@ -16,8 +17,13 @@ export function WelcomeScreen({
   isLoading,
   onCancel,
 }: WelcomeScreenProps) {
+  const wizardEnabled = isWizardEnabled();
+
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center px-4 py-12 lg:px-8">
+    <div
+      className="min-h-screen flex flex-col items-center justify-center px-4 py-12 lg:px-8"
+      data-wizard-enabled={wizardEnabled}
+    >
       <div className="w-full max-w-4xl space-y-8 text-center">
         <div className="flex flex-col items-center gap-3">
           <StatusBadge

--- a/frontend/src/utils/featureFlags.ts
+++ b/frontend/src/utils/featureFlags.ts
@@ -1,0 +1,34 @@
+type BooleanLike = string | boolean | undefined | null;
+
+function normalizeBoolean(value: BooleanLike, defaultValue = false): boolean {
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  const normalized = value.toString().trim().toLowerCase();
+
+  if (normalized === "true") {
+    return true;
+  }
+
+  if (normalized === "false") {
+    return false;
+  }
+
+  return defaultValue;
+}
+
+export function readBooleanFlag(key: string, defaultValue = false): boolean {
+  const env = import.meta.env as Record<string, string | boolean | undefined>;
+  const rawValue = env?.[key];
+  return normalizeBoolean(rawValue, defaultValue);
+}
+
+export function isWizardEnabled(defaultValue = false): boolean {
+  return readBooleanFlag("VITE_ENABLE_WIZARD", defaultValue);
+}
+


### PR DESCRIPTION
## Summary
- add a shared helper to normalize boolean feature flags and expose the wizard toggle
- read the wizard flag in the welcome screen without altering the existing UI flow
- update the implementation checklist to mark the flag normalization task as complete

## Testing
- npm --prefix frontend run build *(fails: Cannot find module '../lib/tsc.js' from the bundled TypeScript package)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4be281188321b8fe4c31c0b095b4