### PR TITLE
feat: add onboarding wizard UI behind feature flag

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -12,51 +12,51 @@
 
 ## 2. Preservação da UI Atual
 - [x] Revisar e confirmar que `frontend/src/components/InputForm.tsx` permanece inalterado
-- [ ] Revisar e confirmar que `frontend/src/components/WelcomeScreen.tsx` mantém o markup atual para o modo clássico
-- [ ] Revisar e confirmar que `frontend/src/App.tsx`, `ChatMessagesView.tsx` e `ActivityTimeline.tsx` não foram modificados além da integração da flag
+- [x] Revisar e confirmar que `frontend/src/components/WelcomeScreen.tsx` mantém o markup atual para o modo clássico
+- [x] Revisar e confirmar que `frontend/src/App.tsx`, `ChatMessagesView.tsx` e `ActivityTimeline.tsx` não foram modificados além da integração da flag
 
 ## 3. Estrutura de Pastas e Arquivos Novos
-- [ ] Criar diretório `frontend/src/components/WizardForm/steps`
-- [ ] Criar arquivo `frontend/src/types/wizard.types.ts`
-- [ ] Criar arquivo `frontend/src/constants/wizard.constants.ts`
-- [ ] Criar arquivo `frontend/src/utils/wizard.utils.ts`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/index.ts`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/WizardForm.tsx`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/ProgressHeader.tsx`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/StepCard.tsx`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/NavigationFooter.tsx`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/steps/LandingPageStep.tsx`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/steps/ObjectiveStep.tsx`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/steps/FormatStep.tsx`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/steps/ProfileStep.tsx`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/steps/FocusStep.tsx`
-- [ ] Criar arquivo `frontend/src/components/WizardForm/steps/ReviewStep.tsx`
+- [x] Criar diretório `frontend/src/components/WizardForm/steps`
+- [x] Criar arquivo `frontend/src/types/wizard.types.ts`
+- [x] Criar arquivo `frontend/src/constants/wizard.constants.ts`
+- [x] Criar arquivo `frontend/src/utils/wizard.utils.ts`
+- [x] Criar arquivo `frontend/src/components/WizardForm/index.ts`
+- [x] Criar arquivo `frontend/src/components/WizardForm/WizardForm.tsx`
+- [x] Criar arquivo `frontend/src/components/WizardForm/ProgressHeader.tsx`
+- [x] Criar arquivo `frontend/src/components/WizardForm/StepCard.tsx`
+- [x] Criar arquivo `frontend/src/components/WizardForm/NavigationFooter.tsx`
+- [x] Criar arquivo `frontend/src/components/WizardForm/steps/LandingPageStep.tsx`
+- [x] Criar arquivo `frontend/src/components/WizardForm/steps/ObjectiveStep.tsx`
+- [x] Criar arquivo `frontend/src/components/WizardForm/steps/FormatStep.tsx`
+- [x] Criar arquivo `frontend/src/components/WizardForm/steps/ProfileStep.tsx`
+- [x] Criar arquivo `frontend/src/components/WizardForm/steps/FocusStep.tsx`
+- [x] Criar arquivo `frontend/src/components/WizardForm/steps/ReviewStep.tsx`
 
 ## 4. Implementação dos Tipos, Constantes e Utilitários
-- [ ] Preencher `wizard.types.ts` com as interfaces `WizardFormState`, `WizardValidationErrors`, `ValidationRule` e `WizardStep`
-- [ ] Preencher `wizard.constants.ts` com `WIZARD_INITIAL_STATE`, `WIZARD_STEPS`, `OBJETIVO_OPTIONS` e `FORMATO_OPTIONS`
-- [ ] Implementar `wizard.utils.ts` com as funções `validateStepField`, `getCompletedSteps`, `canProceed`, `validateForm` e `formatSubmitPayload`
+- [x] Preencher `wizard.types.ts` com as interfaces `WizardFormState`, `WizardValidationErrors`, `ValidationRule` e `WizardStep`
+- [x] Preencher `wizard.constants.ts` com `WIZARD_INITIAL_STATE`, `WIZARD_STEPS`, `OBJETIVO_OPTIONS` e `FORMATO_OPTIONS`
+- [x] Implementar `wizard.utils.ts` com as funções `validateStepField`, `getCompletedSteps`, `canProceed`, `validateForm` e `formatSubmitPayload`
 
 ## 5. Implementação dos Componentes do Wizard
-- [ ] Implementar lógica principal em `WizardForm.tsx` (state, navegação, submit, renderização condicional dos steps)
-- [ ] Implementar `ProgressHeader.tsx` exibindo stepper e progresso
-- [ ] Implementar `StepCard.tsx` como container padrão dos conteúdos dos steps
-- [ ] Implementar `NavigationFooter.tsx` com botões Voltar/Próximo/Gerar e botão Cancelar quando `isLoading`
-- [ ] Implementar `LandingPageStep.tsx` com input, dicas e tratamento de erros
-- [ ] Implementar `ObjectiveStep.tsx` com cards selecionáveis baseados em `OBJETIVO_OPTIONS`
-- [ ] Implementar `FormatStep.tsx` com cards selecionáveis baseados em `FORMATO_OPTIONS`
-- [ ] Implementar `ProfileStep.tsx` com textarea, contador de caracteres e validação visual
-- [ ] Implementar `FocusStep.tsx` com textarea opcional e indicação de campo
-- [ ] Implementar `ReviewStep.tsx` listando dados finais e botões “Editar”
+- [x] Implementar lógica principal em `WizardForm.tsx` (state, navegação, submit, renderização condicional dos steps)
+- [x] Implementar `ProgressHeader.tsx` exibindo stepper e progresso
+- [x] Implementar `StepCard.tsx` como container padrão dos conteúdos dos steps
+- [x] Implementar `NavigationFooter.tsx` com botões Voltar/Próximo/Gerar e botão Cancelar quando `isLoading`
+- [x] Implementar `LandingPageStep.tsx` com input, dicas e tratamento de erros
+- [x] Implementar `ObjectiveStep.tsx` com cards selecionáveis baseados em `OBJETIVO_OPTIONS`
+- [x] Implementar `FormatStep.tsx` com cards selecionáveis baseados em `FORMATO_OPTIONS`
+- [x] Implementar `ProfileStep.tsx` com textarea, contador de caracteres e validação visual
+- [x] Implementar `FocusStep.tsx` com textarea opcional e indicação de campo
+- [x] Implementar `ReviewStep.tsx` listando dados finais e botões “Editar”
 
 ## 6. Integração Condicional na WelcomeScreen
-- [ ] Importar `WizardForm` e `InputForm` em `frontend/src/components/WelcomeScreen.tsx`
-- [ ] Ler e normalizar `VITE_ENABLE_WIZARD` no topo do arquivo
-- [ ] Renderizar `WizardForm` quando a flag estiver ativa e manter o markup atual quando desativada
+- [x] Importar `WizardForm` e `InputForm` em `frontend/src/components/WelcomeScreen.tsx`
+- [x] Ler e normalizar `VITE_ENABLE_WIZARD` no topo do arquivo
+- [x] Renderizar `WizardForm` quando a flag estiver ativa e manter o markup atual quando desativada
 
 ## 7. Verificações de Estilo e Tokens
-- [ ] Garantir uso exclusivo de classes já suportadas (ex.: `bg-card`, `border-border`, `text-muted-foreground`)
-- [ ] Adicionar novos tokens em `global.css` apenas se necessário, sem sobrescrever existentes
+- [x] Garantir uso exclusivo de classes já suportadas (ex.: `bg-card`, `border-border`, `text-muted-foreground`)
+- [x] Adicionar novos tokens em `global.css` apenas se necessário, sem sobrescrever existentes
 
 ## 8. Testes e QA
 - [ ] Testar fluxo completo com flag desativada (`VITE_ENABLE_WIZARD=false`)

--- a/frontend/src/components/WelcomeScreen.tsx
+++ b/frontend/src/components/WelcomeScreen.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { SectionCard } from "@/components/ui/section-card";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { InputForm } from "@/components/InputForm";
-import { isWizardEnabled } from "@/utils/featureFlags";
+import { WizardForm } from "@/components/WizardForm";
 
 interface WelcomeScreenProps {
   handleSubmit: (query: string) => void;
@@ -17,7 +17,17 @@ export function WelcomeScreen({
   isLoading,
   onCancel,
 }: WelcomeScreenProps) {
-  const wizardEnabled = isWizardEnabled();
+  const wizardEnabled = (import.meta.env.VITE_ENABLE_WIZARD ?? "false")
+    .toString()
+    .toLowerCase() === "true";
+
+  if (wizardEnabled) {
+    return (
+      <div data-wizard-enabled>
+        <WizardForm onSubmit={handleSubmit} isLoading={isLoading} onCancel={onCancel} />
+      </div>
+    );
+  }
 
   return (
     <div

--- a/frontend/src/components/WizardForm/NavigationFooter.tsx
+++ b/frontend/src/components/WizardForm/NavigationFooter.tsx
@@ -1,0 +1,80 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/utils';
+
+interface NavigationFooterProps {
+  currentStep: number;
+  totalSteps: number;
+  onNext: () => void;
+  onBack: () => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  canProceed: boolean;
+  isLoading: boolean;
+  isOptional: boolean;
+}
+
+export function NavigationFooter({
+  currentStep,
+  totalSteps,
+  onNext,
+  onBack,
+  onSubmit,
+  onCancel,
+  canProceed,
+  isLoading,
+  isOptional,
+}: NavigationFooterProps) {
+  const isFirstStep = currentStep === 0;
+  const isLastStep = currentStep === totalSteps - 1;
+
+  return (
+    <footer className="border-t border-border/60 pt-4">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+          <Button
+            type="button"
+            variant="ghost"
+            className="gap-2 text-muted-foreground hover:text-foreground"
+            disabled={isFirstStep || isLoading}
+            onClick={onBack}
+          >
+            Voltar
+          </Button>
+          <span className="hidden text-xs uppercase tracking-wider text-muted-foreground/80 md:inline">
+            Passo {Math.min(currentStep + 1, totalSteps)} de {totalSteps}
+          </span>
+          {isOptional && (
+            <span className="inline-flex items-center rounded-full border border-dashed border-border/60 px-3 py-1 text-xs text-muted-foreground">
+              Etapa opcional
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-end">
+          {isLoading && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onCancel}
+              className="justify-center text-destructive hover:text-destructive/80"
+            >
+              Cancelar geração
+            </Button>
+          )}
+          <Button
+            type="button"
+            size="lg"
+            className={cn(
+              'min-w-[160px] justify-center font-medium transition-colors',
+              !canProceed && 'opacity-60',
+            )}
+            disabled={!canProceed || isLoading}
+            onClick={isLastStep ? onSubmit : onNext}
+          >
+            {isLastStep ? 'Gerar anúncios' : 'Próximo passo'}
+          </Button>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/components/WizardForm/ProgressHeader.tsx
+++ b/frontend/src/components/WizardForm/ProgressHeader.tsx
@@ -1,0 +1,78 @@
+import type { WizardStep } from '@/types/wizard.types';
+import { cn } from '@/utils';
+
+interface ProgressHeaderProps {
+  steps: WizardStep[];
+  currentStep: number;
+  completedSteps: number[];
+}
+
+export function ProgressHeader({
+  steps,
+  currentStep,
+  completedSteps,
+}: ProgressHeaderProps) {
+  const totalSteps = steps.length;
+  const progressValue = Math.max(0, Math.min(currentStep, totalSteps - 1));
+  const progressPercentage = ((progressValue + 1) / totalSteps) * 100;
+
+  return (
+    <header className="space-y-6">
+      <div className="flex flex-col gap-2">
+        <span className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+          Passo {Math.min(currentStep + 1, totalSteps)} de {totalSteps}
+        </span>
+        <h1 className="text-2xl font-semibold text-foreground">
+          Monte seu briefing guiado
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Avance pelas etapas para garantir que todos os dados essenciais sejam preenchidos
+          antes de gerar as recomendações de anúncios.
+        </p>
+      </div>
+
+      <div className="h-2 w-full overflow-hidden rounded-full bg-border/70">
+        <div
+          className="h-full rounded-full bg-primary transition-all duration-300"
+          style={{ width: `${progressPercentage}%` }}
+        />
+      </div>
+
+      <ol className="flex flex-wrap items-center gap-4">
+        {steps.map((step, index) => {
+          const isActive = index === currentStep;
+          const isCompleted = completedSteps.includes(index);
+
+          return (
+            <li
+              key={step.id}
+              className={cn(
+                'flex items-center gap-3 rounded-xl border px-3 py-2 transition-colors text-sm',
+                isActive && 'border-primary/60 bg-primary/10 text-primary',
+                !isActive && 'border-border/60 bg-card/60 text-muted-foreground',
+                isCompleted && !isActive && 'border-primary/50 bg-primary/10 text-primary',
+              )}
+            >
+              <div
+                className={cn(
+                  'flex h-8 w-8 items-center justify-center rounded-full border text-xs font-semibold',
+                  isActive && 'border-primary/40 bg-primary text-primary-foreground',
+                  isCompleted && !isActive && 'border-primary/40 bg-primary/90 text-primary-foreground',
+                  !isActive && !isCompleted && 'border-border/80 bg-card text-muted-foreground',
+                )}
+              >
+                {index + 1}
+              </div>
+              <div className="flex flex-col">
+                <span className="font-medium text-foreground/90">{step.title}</span>
+                {step.subtitle && (
+                  <span className="text-xs text-muted-foreground">{step.subtitle}</span>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </header>
+  );
+}

--- a/frontend/src/components/WizardForm/StepCard.tsx
+++ b/frontend/src/components/WizardForm/StepCard.tsx
@@ -1,0 +1,34 @@
+import type { WizardStep } from '@/types/wizard.types';
+import { cn } from '@/utils';
+
+interface StepCardProps {
+  step: WizardStep;
+  children: React.ReactNode;
+}
+
+export function StepCard({ step, children }: StepCardProps) {
+  return (
+    <section
+      className={cn(
+        'bg-card border border-border/60 rounded-2xl shadow-lg',
+        'p-8 flex flex-col gap-6',
+      )}
+    >
+      <header className="flex items-start gap-4">
+        <div className="rounded-xl bg-primary/15 text-primary p-3">
+          <step.icon className="h-6 w-6" />
+        </div>
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold text-foreground">{step.title}</h2>
+          {step.subtitle && (
+            <span className="text-xs uppercase tracking-wide text-muted-foreground">
+              {step.subtitle}
+            </span>
+          )}
+          <p className="text-sm text-muted-foreground">{step.description}</p>
+        </div>
+      </header>
+      <div>{children}</div>
+    </section>
+  );
+}

--- a/frontend/src/components/WizardForm/WizardForm.tsx
+++ b/frontend/src/components/WizardForm/WizardForm.tsx
@@ -1,0 +1,248 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import type {
+  WizardFormState,
+  WizardValidationErrors,
+} from '@/types/wizard.types';
+import {
+  WIZARD_INITIAL_STATE,
+  WIZARD_STEPS,
+} from '@/constants/wizard.constants';
+import {
+  canProceed,
+  formatSubmitPayload,
+  getCompletedSteps,
+  validateForm,
+  validateStepField,
+} from '@/utils/wizard.utils';
+
+import { ProgressHeader } from './ProgressHeader';
+import { StepCard } from './StepCard';
+import { NavigationFooter } from './NavigationFooter';
+import { LandingPageStep } from './steps/LandingPageStep';
+import { ObjectiveStep } from './steps/ObjectiveStep';
+import { FormatStep } from './steps/FormatStep';
+import { ProfileStep } from './steps/ProfileStep';
+import { FocusStep } from './steps/FocusStep';
+import { ReviewStep } from './steps/ReviewStep';
+
+type WizardField = keyof WizardFormState;
+
+interface WizardFormProps {
+  onSubmit: (payload: string) => void;
+  isLoading: boolean;
+  onCancel: () => void;
+}
+
+export function WizardForm({ onSubmit, isLoading, onCancel }: WizardFormProps) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [formState, setFormState] =
+    useState<WizardFormState>(WIZARD_INITIAL_STATE);
+  const [errors, setErrors] = useState<WizardValidationErrors>({});
+  const [touched, setTouched] = useState<Set<WizardField>>(new Set());
+
+  const currentWizardStep = WIZARD_STEPS[currentStep];
+
+  const completedSteps = useMemo(
+    () => getCompletedSteps(formState, currentStep),
+    [formState, currentStep],
+  );
+
+  const markFieldTouched = useCallback((field: WizardField) => {
+    setTouched(prevTouched => {
+      if (prevTouched.has(field)) {
+        return prevTouched;
+      }
+      const updated = new Set(prevTouched);
+      updated.add(field);
+      return updated;
+    });
+  }, []);
+
+  const updateFieldError = useCallback(
+    (field: WizardField, value: string, nextState: WizardFormState) => {
+      const step = WIZARD_STEPS.find(item => item.id === field);
+      if (!step) {
+        return;
+      }
+
+      const validationError = validateStepField(step, value, nextState);
+      setErrors(prevErrors => {
+        if (validationError) {
+          return { ...prevErrors, [field]: validationError };
+        }
+
+        if (!(field in prevErrors)) {
+          return prevErrors;
+        }
+
+        const { [field]: _, ...rest } = prevErrors;
+        return rest;
+      });
+    },
+    [],
+  );
+
+  const handleFieldChange = useCallback(
+    (field: WizardField, value: string) => {
+      setFormState(prevState => {
+        const nextState = { ...prevState, [field]: value };
+        markFieldTouched(field);
+        updateFieldError(field, value, nextState);
+        return nextState;
+      });
+    },
+    [markFieldTouched, updateFieldError],
+  );
+
+  const goToStep = useCallback((stepIndex: number) => {
+    setCurrentStep(() => {
+      if (stepIndex < 0) {
+        return 0;
+      }
+      if (stepIndex >= WIZARD_STEPS.length) {
+        return WIZARD_STEPS.length - 1;
+      }
+      return stepIndex;
+    });
+  }, []);
+
+  const handleNext = useCallback(() => {
+    const step = WIZARD_STEPS[currentStep];
+    if (!step || step.id === 'review') {
+      return;
+    }
+
+    const field = step.id;
+    const value = formState[field];
+    markFieldTouched(field);
+    updateFieldError(field, value, formState);
+
+    const validationError = validateStepField(step, value, formState);
+    if (validationError) {
+      setErrors(prev => ({ ...prev, [field]: validationError }));
+      return;
+    }
+
+    goToStep(currentStep + 1);
+  }, [currentStep, formState, goToStep, markFieldTouched, updateFieldError]);
+
+  const handleBack = useCallback(() => {
+    goToStep(currentStep - 1);
+  }, [currentStep, goToStep]);
+
+  const handleSubmit = useCallback(() => {
+    const validationErrors = validateForm(formState);
+    setErrors(validationErrors);
+
+    const errorFields = Object.keys(validationErrors) as WizardField[];
+    if (errorFields.length > 0) {
+      setTouched(prevTouched => {
+        const updated = new Set(prevTouched);
+        errorFields.forEach(field => updated.add(field));
+        return updated;
+      });
+
+      const firstErrorStep = WIZARD_STEPS.findIndex(
+        step => step.id !== 'review' && validationErrors[step.id as WizardField],
+      );
+
+      if (firstErrorStep >= 0) {
+        goToStep(firstErrorStep);
+      }
+      return;
+    }
+
+    const payload = formatSubmitPayload(formState);
+    onSubmit(payload);
+  }, [formState, goToStep, onSubmit]);
+
+  const handleEditStep = useCallback(
+    (field: WizardField) => {
+      const stepIndex = WIZARD_STEPS.findIndex(step => step.id === field);
+      if (stepIndex >= 0) {
+        goToStep(stepIndex);
+      }
+    },
+    [goToStep],
+  );
+
+  const renderStepContent = useCallback(() => {
+    if (!currentWizardStep) {
+      return null;
+    }
+
+    switch (currentWizardStep.id) {
+      case 'landing_page_url':
+        return (
+          <LandingPageStep
+            value={formState.landing_page_url}
+            onChange={value => handleFieldChange('landing_page_url', value)}
+            error={touched.has('landing_page_url') ? errors.landing_page_url : undefined}
+          />
+        );
+      case 'objetivo_final':
+        return (
+          <ObjectiveStep
+            value={formState.objetivo_final}
+            onChange={value => handleFieldChange('objetivo_final', value)}
+            error={touched.has('objetivo_final') ? errors.objetivo_final : undefined}
+          />
+        );
+      case 'formato_anuncio':
+        return (
+          <FormatStep
+            value={formState.formato_anuncio}
+            onChange={value => handleFieldChange('formato_anuncio', value)}
+            error={touched.has('formato_anuncio') ? errors.formato_anuncio : undefined}
+          />
+        );
+      case 'perfil_cliente':
+        return (
+          <ProfileStep
+            value={formState.perfil_cliente}
+            onChange={value => handleFieldChange('perfil_cliente', value)}
+            error={touched.has('perfil_cliente') ? errors.perfil_cliente : undefined}
+          />
+        );
+      case 'foco':
+        return (
+          <FocusStep
+            value={formState.foco}
+            onChange={value => handleFieldChange('foco', value)}
+            error={touched.has('foco') ? errors.foco : undefined}
+          />
+        );
+      case 'review':
+        return <ReviewStep formState={formState} onEdit={handleEditStep} />;
+      default:
+        return null;
+    }
+  }, [currentWizardStep, errors, formState, handleEditStep, handleFieldChange, touched]);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background px-4 py-8">
+      <div className="mx-auto w-full max-w-2xl flex-1 flex flex-col gap-6">
+        <ProgressHeader
+          steps={WIZARD_STEPS}
+          currentStep={currentStep}
+          completedSteps={completedSteps}
+        />
+
+        <StepCard step={currentWizardStep}>{renderStepContent()}</StepCard>
+
+        <NavigationFooter
+          currentStep={currentStep}
+          totalSteps={WIZARD_STEPS.length}
+          onNext={handleNext}
+          onBack={handleBack}
+          onSubmit={handleSubmit}
+          onCancel={onCancel}
+          canProceed={canProceed(currentStep, formState, errors)}
+          isLoading={isLoading}
+          isOptional={Boolean(currentWizardStep?.isOptional)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WizardForm/index.ts
+++ b/frontend/src/components/WizardForm/index.ts
@@ -1,0 +1,1 @@
+export { WizardForm } from './WizardForm';

--- a/frontend/src/components/WizardForm/steps/FocusStep.tsx
+++ b/frontend/src/components/WizardForm/steps/FocusStep.tsx
@@ -1,0 +1,44 @@
+import { AlertCircle, Info } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
+
+interface FocusStepProps {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+export function FocusStep({ value, onChange, error }: FocusStepProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <label className="text-sm font-medium text-foreground/90">
+            Há alguma ênfase ou mensagem obrigatória?
+          </label>
+          <Badge variant="outline" className="border-dashed border-border/60 text-muted-foreground">
+            Opcional
+          </Badge>
+        </div>
+        <Textarea
+          value={value}
+          onChange={event => onChange(event.target.value)}
+          rows={5}
+          placeholder="Ex.: destaque para frete grátis, cupom promocional, benefícios ou temas que devem ser evitados."
+        />
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Info className="h-4 w-4" />
+          Este campo ajuda o assistente a reforçar diferenciais importantes, mas pode ser deixado em branco.
+        </div>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/60 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WizardForm/steps/FormatStep.tsx
+++ b/frontend/src/components/WizardForm/steps/FormatStep.tsx
@@ -1,0 +1,54 @@
+import { AlertCircle, LayoutDashboard } from 'lucide-react';
+
+import { FORMATO_OPTIONS } from '@/constants/wizard.constants';
+import { cn } from '@/utils';
+
+interface FormatStepProps {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+export function FormatStep({ value, onChange, error }: FormatStepProps) {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <p className="text-sm text-muted-foreground">
+          Escolha o formato que combina com o criativo disponível e o posicionamento onde deseja anunciar.
+        </p>
+        <LayoutDashboard className="hidden h-8 w-8 text-primary/80 sm:block" />
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        {FORMATO_OPTIONS.map(option => {
+          const isSelected = value === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onChange(option.value)}
+              className={cn(
+                'flex flex-col items-start gap-1 rounded-2xl border px-4 py-4 text-left transition-all',
+                'bg-card/80 hover:border-primary/60 hover:bg-primary/5',
+                isSelected && 'border-primary bg-primary/10 shadow-md text-primary',
+              )}
+            >
+              <span className="text-sm font-semibold text-foreground/90">
+                {option.label}
+              </span>
+              <span className="text-xs text-muted-foreground">Proporção {option.ratio}</span>
+              <span className="text-xs text-muted-foreground/80">{option.description}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/60 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WizardForm/steps/LandingPageStep.tsx
+++ b/frontend/src/components/WizardForm/steps/LandingPageStep.tsx
@@ -1,0 +1,69 @@
+import { AlertCircle, Sparkles } from 'lucide-react';
+
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface LandingPageStepProps {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+const examples = [
+  'https://minhaempresa.com/consultas',
+  'https://lojaonline.com/ofertas',
+  'https://agenciaxyz.com/contato',
+];
+
+export function LandingPageStep({ value, onChange, error }: LandingPageStepProps) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-sm font-medium text-foreground/90">
+          URL da página de destino
+          <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary">
+            <Sparkles className="h-3 w-3" />
+            Otimize conversões
+          </span>
+        </div>
+        <Input
+          type="url"
+          value={value}
+          onChange={event => onChange(event.target.value)}
+          placeholder="https://exemplo.com/pagina"
+          autoComplete="url"
+        />
+        <p className="text-sm text-muted-foreground">
+          Dica: utilize uma URL específica da campanha para acompanhar métricas com maior precisão.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">
+          Exemplos rápidos
+        </span>
+        <div className="flex flex-wrap gap-2">
+          {examples.map(example => (
+            <Button
+              key={example}
+              type="button"
+              variant="outline"
+              size="sm"
+              className="text-xs"
+              onClick={() => onChange(example)}
+            >
+              {example}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/60 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WizardForm/steps/ObjectiveStep.tsx
+++ b/frontend/src/components/WizardForm/steps/ObjectiveStep.tsx
@@ -1,0 +1,53 @@
+import { AlertCircle, Target } from 'lucide-react';
+
+import { OBJETIVO_OPTIONS } from '@/constants/wizard.constants';
+import { cn } from '@/utils';
+
+interface ObjectiveStepProps {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+export function ObjectiveStep({ value, onChange, error }: ObjectiveStepProps) {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <p className="text-sm text-muted-foreground">
+          Escolha o resultado que melhor representa a meta desta campanha. Isso ajuda o assistente a priorizar mensagens e CTA adequados.
+        </p>
+        <Target className="hidden h-8 w-8 text-primary/80 sm:block" />
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {OBJETIVO_OPTIONS.map(option => {
+          const isSelected = value === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onChange(option.value)}
+              className={cn(
+                'flex flex-col items-start gap-1 rounded-2xl border px-4 py-4 text-left transition-all',
+                'bg-card/80 hover:border-primary/60 hover:bg-primary/5',
+                isSelected && 'border-primary bg-primary/10 shadow-md text-primary',
+              )}
+            >
+              <span className="text-sm font-semibold text-foreground/90">
+                {option.label}
+              </span>
+              <span className="text-xs text-muted-foreground">{option.description}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/60 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WizardForm/steps/ProfileStep.tsx
+++ b/frontend/src/components/WizardForm/steps/ProfileStep.tsx
@@ -1,0 +1,48 @@
+import { AlertCircle } from 'lucide-react';
+
+import { Textarea } from '@/components/ui/textarea';
+
+interface ProfileStepProps {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+const MAX_CHARACTERS = 500;
+const WARNING_THRESHOLD = Math.floor(MAX_CHARACTERS * 0.9);
+
+export function ProfileStep({ value, onChange, error }: ProfileStepProps) {
+  const charactersUsed = value.length;
+  const isNearLimit = charactersUsed >= WARNING_THRESHOLD;
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-foreground/90">
+          Quem é o cliente ideal?
+        </label>
+        <Textarea
+          value={value}
+          onChange={event => onChange(event.target.value)}
+          rows={6}
+          placeholder="Descreva persona, desafios, preferências, tom de voz e diferenciais que importam para a campanha."
+        />
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>
+            Inclua detalhes sobre dores, desejos e gatilhos de decisão.
+          </span>
+          <span className={isNearLimit ? 'text-amber-500' : undefined}>
+            {charactersUsed}/{MAX_CHARACTERS}
+          </span>
+        </div>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/60 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WizardForm/steps/ReviewStep.tsx
+++ b/frontend/src/components/WizardForm/steps/ReviewStep.tsx
@@ -1,0 +1,68 @@
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { WIZARD_STEPS } from '@/constants/wizard.constants';
+import type { WizardFormState } from '@/types/wizard.types';
+
+interface ReviewStepProps {
+  formState: WizardFormState;
+  onEdit: (field: keyof WizardFormState) => void;
+}
+
+export function ReviewStep({ formState, onEdit }: ReviewStepProps) {
+  const fields = WIZARD_STEPS.filter(step => step.id !== 'review');
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Revise as informações antes de gerar os anúncios. Você pode editar qualquer etapa clicando em “Editar”.
+      </p>
+
+      <div className="space-y-3">
+        {fields.map(step => {
+          const fieldId = step.id as keyof WizardFormState;
+          const value = formState[fieldId].trim();
+          const isEmpty = value.length === 0;
+
+          return (
+            <div
+              key={step.id}
+              className="flex flex-col gap-2 rounded-xl border border-border/60 bg-card/60 p-4 sm:flex-row sm:items-start sm:justify-between"
+            >
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-semibold text-foreground/90">{step.title}</h3>
+                  {step.isOptional && (
+                    <Badge variant="outline" className="border-dashed border-border/60 text-xs text-muted-foreground">
+                      Opcional
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">{step.subtitle}</p>
+                <p className="text-sm text-muted-foreground/80">{step.description}</p>
+              </div>
+
+              <div className="flex flex-col items-start gap-3 sm:w-1/2">
+                <div className="rounded-lg bg-background/80 px-3 py-2 text-sm text-foreground/90">
+                  {isEmpty ? (
+                    <span className="italic text-muted-foreground">Não preenchido</span>
+                  ) : (
+                    <span className="whitespace-pre-wrap break-words">{value}</span>
+                  )}
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onEdit(fieldId)}
+                  className="self-end"
+                >
+                  Editar
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/constants/wizard.constants.ts
+++ b/frontend/src/constants/wizard.constants.ts
@@ -1,0 +1,161 @@
+import {
+  CheckCircle,
+  Layout,
+  LinkIcon,
+  Sparkles,
+  Target,
+  Users,
+} from 'lucide-react';
+
+import type { WizardFormState, WizardStep } from '@/types/wizard.types';
+
+export const WIZARD_INITIAL_STATE: WizardFormState = {
+  landing_page_url: '',
+  objetivo_final: '',
+  formato_anuncio: '',
+  perfil_cliente: '',
+  foco: '',
+};
+
+export const OBJETIVO_OPTIONS = [
+  { value: 'agendamentos', label: 'Agendamentos', description: 'Marcar consultas ou reuniões' },
+  { value: 'leads', label: 'Geração de Leads', description: 'Capturar contatos qualificados' },
+  { value: 'vendas', label: 'Vendas Diretas', description: 'Converter em vendas imediatas' },
+  { value: 'contato', label: 'Contato', description: 'Receber mensagens e interações' },
+] as const;
+
+export const FORMATO_OPTIONS = [
+  { value: 'Feed', label: 'Feed', ratio: '1:1 ou 4:5', description: 'Posts no feed principal' },
+  { value: 'Stories', label: 'Stories', ratio: '9:16', description: 'Conteúdo vertical temporário' },
+  { value: 'Reels', label: 'Reels', ratio: '9:16', description: 'Vídeos curtos e envolventes' },
+] as const;
+
+const objetivoValues = new Set<string>(OBJETIVO_OPTIONS.map(option => option.value));
+const formatoValues = new Set<string>(FORMATO_OPTIONS.map(option => option.value));
+
+export const WIZARD_STEPS: WizardStep[] = [
+  {
+    id: 'landing_page_url',
+    title: 'Qual é a página de destino?',
+    subtitle: 'Passo 1',
+    description: 'Informe a URL principal onde as pessoas devem chegar após clicarem no anúncio.',
+    icon: LinkIcon,
+    validationRules: [
+      {
+        field: 'landing_page_url',
+        validate: value => {
+          const trimmedValue = value.trim();
+          if (!trimmedValue) {
+            return 'Informe a URL da página de destino.';
+          }
+
+          try {
+            const parsedUrl = new URL(trimmedValue);
+            if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+              return 'Utilize URLs iniciadas com http:// ou https://';
+            }
+          } catch (error) {
+            return 'Digite uma URL válida, incluindo http(s)://';
+          }
+
+          return null;
+        },
+      },
+    ],
+  },
+  {
+    id: 'objetivo_final',
+    title: 'Qual é o objetivo principal?',
+    subtitle: 'Passo 2',
+    description: 'Escolha o resultado desejado para medir o sucesso da campanha.',
+    icon: Target,
+    validationRules: [
+      {
+        field: 'objetivo_final',
+        validate: value => {
+          if (!value.trim()) {
+            return 'Selecione um objetivo para a campanha.';
+          }
+
+          if (!objetivoValues.has(value)) {
+            return 'Escolha um objetivo disponível na lista.';
+          }
+
+          return null;
+        },
+      },
+    ],
+  },
+  {
+    id: 'formato_anuncio',
+    title: 'Qual formato será utilizado?',
+    subtitle: 'Passo 3',
+    description: 'Selecione o formato que melhor se adapta ao criativo e ao canal escolhido.',
+    icon: Layout,
+    validationRules: [
+      {
+        field: 'formato_anuncio',
+        validate: value => {
+          if (!value.trim()) {
+            return 'Selecione um formato de anúncio.';
+          }
+
+          if (!formatoValues.has(value)) {
+            return 'Escolha um formato válido.';
+          }
+
+          return null;
+        },
+      },
+    ],
+  },
+  {
+    id: 'perfil_cliente',
+    title: 'Descreva o público ideal',
+    subtitle: 'Passo 4',
+    description: 'Resuma quem é o cliente ideal, dores, desejos e comportamentos.',
+    icon: Users,
+    validationRules: [
+      {
+        field: 'perfil_cliente',
+        validate: value => {
+          const trimmed = value.trim();
+          if (!trimmed) {
+            return 'Descreva brevemente o público do anúncio.';
+          }
+
+          if (trimmed.length < 20) {
+            return 'Use pelo menos 20 caracteres para detalhar o público.';
+          }
+
+          if (trimmed.length > 500) {
+            return 'Resuma o perfil em no máximo 500 caracteres.';
+          }
+
+          return null;
+        },
+      },
+    ],
+  },
+  {
+    id: 'foco',
+    title: 'Algum foco específico?',
+    subtitle: 'Passo 5',
+    description: 'Compartilhe diferenciais, promoções ou mensagens obrigatórias (opcional).',
+    icon: Sparkles,
+    isOptional: true,
+    validationRules: [
+      {
+        field: 'foco',
+        validate: () => null,
+      },
+    ],
+  },
+  {
+    id: 'review',
+    title: 'Revise antes de gerar',
+    subtitle: 'Passo 6',
+    description: 'Confira os dados informados e edite qualquer etapa antes de gerar os anúncios.',
+    icon: CheckCircle,
+  },
+];

--- a/frontend/src/types/wizard.types.ts
+++ b/frontend/src/types/wizard.types.ts
@@ -1,0 +1,32 @@
+import type { ComponentType } from 'react';
+
+export interface WizardFormState {
+  landing_page_url: string;
+  objetivo_final: string;
+  formato_anuncio: string;
+  perfil_cliente: string;
+  foco: string;
+}
+
+export interface WizardValidationErrors {
+  landing_page_url?: string;
+  objetivo_final?: string;
+  formato_anuncio?: string;
+  perfil_cliente?: string;
+  foco?: string;
+}
+
+export interface ValidationRule {
+  field: keyof WizardFormState;
+  validate: (value: string, state: WizardFormState) => string | null;
+}
+
+export interface WizardStep {
+  id: keyof WizardFormState | 'review';
+  title: string;
+  subtitle?: string;
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+  isOptional?: boolean;
+  validationRules?: ValidationRule[];
+}

--- a/frontend/src/utils/wizard.utils.ts
+++ b/frontend/src/utils/wizard.utils.ts
@@ -1,0 +1,122 @@
+import type {
+  WizardFormState,
+  WizardValidationErrors,
+  WizardStep,
+} from '@/types/wizard.types';
+
+import { WIZARD_STEPS } from '@/constants/wizard.constants';
+
+function getStepByIndex(index: number): WizardStep | undefined {
+  return WIZARD_STEPS[index];
+}
+
+export function validateStepField(
+  step: WizardStep,
+  value: string,
+  formState: WizardFormState,
+): string | null {
+  if (!step.validationRules || step.validationRules.length === 0) {
+    return null;
+  }
+
+  for (const rule of step.validationRules) {
+    const fieldValue =
+      rule.field === step.id ? value : formState[rule.field] ?? '';
+    const error = rule.validate(fieldValue, formState);
+    if (error) {
+      return error;
+    }
+  }
+
+  return null;
+}
+
+export function getCompletedSteps(
+  formState: WizardFormState,
+  currentStep: number,
+): number[] {
+  const completed: number[] = [];
+
+  WIZARD_STEPS.forEach((step, index) => {
+    if (index >= currentStep) {
+      return;
+    }
+
+    if (step.id === 'review') {
+      completed.push(index);
+      return;
+    }
+
+    const value = formState[step.id];
+    const error = validateStepField(step, value, formState);
+    if (!error) {
+      completed.push(index);
+    }
+  });
+
+  return completed;
+}
+
+export function canProceed(
+  currentStep: number,
+  formState: WizardFormState,
+  errors: WizardValidationErrors,
+): boolean {
+  const step = getStepByIndex(currentStep);
+  if (!step) {
+    return false;
+  }
+
+  if (step.id === 'review') {
+    return Object.values(errors).every(error => !error);
+  }
+
+  const fieldValue = formState[step.id];
+  if (errors[step.id]) {
+    return false;
+  }
+
+  if (!step.isOptional && !fieldValue.trim()) {
+    return false;
+  }
+
+  const validationError = validateStepField(step, fieldValue, formState);
+  return !validationError;
+}
+
+export function validateForm(
+  formState: WizardFormState,
+): WizardValidationErrors {
+  const validationErrors: WizardValidationErrors = {};
+
+  WIZARD_STEPS.forEach(step => {
+    if (step.id === 'review') {
+      return;
+    }
+
+    const value = formState[step.id];
+    const error = validateStepField(step, value, formState);
+    if (error) {
+      validationErrors[step.id] = error;
+    }
+  });
+
+  return validationErrors;
+}
+
+export function formatSubmitPayload(formState: WizardFormState): string {
+  const lines = WIZARD_STEPS.flatMap(step => {
+    if (step.id === 'review') {
+      return [];
+    }
+
+    const value = formState[step.id].trim();
+    if (!value) {
+      return [];
+    }
+
+    return [`${step.title}: ${value}`];
+  });
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- add wizard state typings, constants, and validation helpers to support the multi-step flow
- build WizardForm shell with progress header, shared card shell, navigation footer, and step-specific components
- gate the wizard behind VITE_ENABLE_WIZARD while preserving the existing welcome screen layout when disabled
- update the implementation checklist to reflect completed structure and integration tasks

## Testing
- `npm --prefix frontend run lint` *(fails: missing transitive eslint bundle dependencies in repository toolchain)*
- `VITE_ENABLE_WIZARD=false npm --prefix frontend run build` *(fails: pre-existing TypeScript errors in App and other legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf59b908a083218e8957910fec4be7