### PR TITLE
fix: respect rollout flags for new input fields

### DIFF
--- a/checklist_frontend.md
+++ b/checklist_frontend.md
@@ -60,7 +60,7 @@ Objetivo: adicionar campos opcionais `nome_empresa`, `o_que_a_empresa_faz`, `sex
 
 ## 8) Rollout e flags
 - [x] Rollout em duas fases: (1) backend primeiro; (2) frontend depois.
-- [ ] Opcional: adicionar flag `VITE_ENABLE_NEW_FIELDS` para esconder os novos steps até finalizar o rollout.
+- [x] Opcional: adicionar flag `VITE_ENABLE_NEW_FIELDS` para esconder os novos steps até finalizar o rollout.
 
 ## 9) Documentação
 - [x] Atualizar README com os novos campos e exemplo de payload.

--- a/frontend/src/components/WizardForm/WizardForm.tsx
+++ b/frontend/src/components/WizardForm/WizardForm.tsx
@@ -194,23 +194,23 @@ export function WizardForm({ onSubmit, isLoading, onCancel }: WizardFormProps) {
       case 'nome_empresa':
         return (
           <CompanyInfoStep
-            variant="name"
+            field="nome_empresa"
             value={formState.nome_empresa}
+            error={errors.nome_empresa}
+            touched={touched.has('nome_empresa')}
             onChange={value => handleFieldChange('nome_empresa', value)}
-            error={touched.has('nome_empresa') ? errors.nome_empresa : undefined}
+            onBlur={() => markFieldTouched('nome_empresa')}
           />
         );
       case 'o_que_a_empresa_faz':
         return (
           <CompanyInfoStep
-            variant="description"
+            field="o_que_a_empresa_faz"
             value={formState.o_que_a_empresa_faz}
+            error={errors.o_que_a_empresa_faz}
+            touched={touched.has('o_que_a_empresa_faz')}
             onChange={value => handleFieldChange('o_que_a_empresa_faz', value)}
-            error={
-              touched.has('o_que_a_empresa_faz')
-                ? errors.o_que_a_empresa_faz
-                : undefined
-            }
+            onBlur={() => markFieldTouched('o_que_a_empresa_faz')}
           />
         );
       case 'formato_anuncio':
@@ -241,10 +241,10 @@ export function WizardForm({ onSubmit, isLoading, onCancel }: WizardFormProps) {
         return (
           <GenderTargetStep
             value={formState.sexo_cliente_alvo}
+            error={errors.sexo_cliente_alvo}
+            touched={touched.has('sexo_cliente_alvo')}
             onChange={value => handleFieldChange('sexo_cliente_alvo', value)}
-            error={
-              touched.has('sexo_cliente_alvo') ? errors.sexo_cliente_alvo : undefined
-            }
+            onBlur={() => markFieldTouched('sexo_cliente_alvo')}
           />
         );
       case 'review':
@@ -252,7 +252,7 @@ export function WizardForm({ onSubmit, isLoading, onCancel }: WizardFormProps) {
       default:
         return null;
     }
-  }, [currentWizardStep, errors, formState, handleEditStep, handleFieldChange, touched]);
+  }, [currentWizardStep, errors, formState, handleEditStep, handleFieldChange, markFieldTouched, touched]);
 
   return (
     <div className="h-screen flex flex-col bg-background px-4 md:px-10 py-8 overflow-hidden">

--- a/frontend/src/components/WizardForm/steps/CompanyInfoStep.tsx
+++ b/frontend/src/components/WizardForm/steps/CompanyInfoStep.tsx
@@ -3,32 +3,53 @@ import { AlertCircle, Building2, Briefcase } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 
+type CompanyField = 'nome_empresa' | 'o_que_a_empresa_faz';
+
 interface CompanyInfoStepProps {
-  variant: 'name' | 'description';
+  field: CompanyField;
   value: string;
-  onChange: (value: string) => void;
   error?: string;
+  touched: boolean;
+  onChange: (value: string) => void;
+  onBlur: () => void;
 }
 
-const contentByVariant = {
-  name: {
+const fieldConfig: Record<CompanyField, {
+  label: string;
+  description: string;
+  placeholder: string;
+  Icon: typeof Building2;
+  hint?: string;
+  multiline?: boolean;
+}> = {
+  nome_empresa: {
     label: 'Nome da empresa ou marca',
     description:
       'Esse nome será usado nos textos do anúncio. Utilize a forma como o público já reconhece a marca.',
     placeholder: 'Ex.: Clínica Bem Viver',
     Icon: Building2,
+    multiline: false,
   },
-  description: {
+  o_que_a_empresa_faz: {
     label: 'Como você descreve a empresa?',
     description:
       'Resuma o que a empresa faz, principais produtos ou serviços em uma frase objetiva.',
     placeholder: 'Ex.: Clínica de nutrição especializada em emagrecimento saudável',
     Icon: Briefcase,
+    hint: 'Dica: mencione diferenciais, público atendido ou resultados que reforcem a autoridade da empresa.',
+    multiline: true,
   },
-} as const;
+};
 
-export function CompanyInfoStep({ variant, value, onChange, error }: CompanyInfoStepProps) {
-  const { label, description, placeholder, Icon } = contentByVariant[variant];
+export function CompanyInfoStep({
+  field,
+  value,
+  error,
+  touched,
+  onChange,
+  onBlur,
+}: CompanyInfoStepProps) {
+  const { label, description, placeholder, Icon, hint, multiline } = fieldConfig[field];
 
   return (
     <div className="space-y-4">
@@ -37,33 +58,31 @@ export function CompanyInfoStep({ variant, value, onChange, error }: CompanyInfo
           <Icon className="h-4 w-4 text-primary/70" />
           {label}
         </label>
-        {variant === 'name' ? (
-          <Input
-            value={value}
-            onChange={event => onChange(event.target.value)}
-            placeholder={placeholder}
-            autoComplete="organization"
-            maxLength={100}
-          />
-        ) : (
+        {multiline ? (
           <Textarea
             value={value}
             onChange={event => onChange(event.target.value)}
+            onBlur={onBlur}
             rows={4}
             placeholder={placeholder}
             maxLength={200}
+          />
+        ) : (
+          <Input
+            value={value}
+            onChange={event => onChange(event.target.value)}
+            onBlur={onBlur}
+            placeholder={placeholder}
+            autoComplete="organization"
+            maxLength={100}
           />
         )}
         <p className="text-sm text-muted-foreground">{description}</p>
       </div>
 
-      {variant === 'description' && (
-        <p className="text-xs text-muted-foreground">
-          Dica: mencione diferenciais, público atendido ou resultados que reforcem a autoridade da empresa.
-        </p>
-      )}
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
 
-      {error && (
+      {touched && error && (
         <div className="flex items-center gap-2 rounded-lg border border-destructive/60 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           <AlertCircle className="h-4 w-4" />
           {error}

--- a/frontend/src/components/WizardForm/steps/GenderTargetStep.tsx
+++ b/frontend/src/components/WizardForm/steps/GenderTargetStep.tsx
@@ -6,11 +6,29 @@ import { cn } from '@/utils';
 
 interface GenderTargetStepProps {
   value: string;
-  onChange: (value: string) => void;
   error?: string;
+  touched: boolean;
+  onChange: (value: string) => void;
+  onBlur: () => void;
 }
 
-export function GenderTargetStep({ value, onChange, error }: GenderTargetStepProps) {
+export function GenderTargetStep({
+  value,
+  error,
+  touched,
+  onChange,
+  onBlur,
+}: GenderTargetStepProps) {
+  const handleSelect = (option: string) => {
+    onChange(option);
+    onBlur();
+  };
+
+  const handleClear = () => {
+    onChange('');
+    onBlur();
+  };
+
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -31,7 +49,7 @@ export function GenderTargetStep({ value, onChange, error }: GenderTargetStepPro
             <button
               key={option.value}
               type="button"
-              onClick={() => onChange(option.value)}
+              onClick={() => handleSelect(option.value)}
               className={cn(
                 'flex flex-col items-start gap-1 rounded-2xl border px-4 py-4 text-left transition-all',
                 'bg-card/80 hover:border-primary/60 hover:bg-primary/5',
@@ -45,11 +63,11 @@ export function GenderTargetStep({ value, onChange, error }: GenderTargetStepPro
         })}
       </div>
 
-      <Button type="button" variant="ghost" size="sm" className="self-start text-xs" onClick={() => onChange('')}>
+      <Button type="button" variant="ghost" size="sm" className="self-start text-xs" onClick={handleClear}>
         Limpar seleção
       </Button>
 
-      {error && (
+      {touched && error && (
         <div className="flex items-center gap-2 rounded-lg border border-destructive/60 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           <AlertCircle className="h-4 w-4" />
           {error}

--- a/frontend/src/constants/wizard.constants.ts
+++ b/frontend/src/constants/wizard.constants.ts
@@ -39,6 +39,7 @@ export const FORMATO_OPTIONS = [
 const objetivoValues = new Set<string>(OBJETIVO_OPTIONS.map(option => option.value));
 const formatoValues = new Set<string>(FORMATO_OPTIONS.map(option => option.value));
 const sexoClienteValues = new Set<string>(['masculino', 'feminino', 'neutro']);
+const enableNewFields = (import.meta.env.VITE_ENABLE_NEW_FIELDS ?? 'false') === 'true';
 
 export const SEXO_CLIENTE_OPTIONS = [
   {
@@ -53,207 +54,227 @@ export const SEXO_CLIENTE_OPTIONS = [
   },
   {
     value: 'neutro',
-    label: 'Neutro',
-    description: 'Mensagem inclusiva para todos os públicos',
+    label: 'Neutro/Misto',
+    description: 'Público diversificado',
   },
 ] as const;
 
-export const WIZARD_STEPS: WizardStep[] = [
-  {
-    id: 'landing_page_url',
-    title: 'Qual é a página de destino?',
-    subtitle: 'Passo 1',
-    description: 'Informe a URL principal onde as pessoas devem chegar após clicarem no anúncio.',
-    icon: LinkIcon,
-    validationRules: [
-      {
-        field: 'landing_page_url',
-        validate: value => {
-          const trimmedValue = value.trim();
-          if (!trimmedValue) {
-            return 'Informe a URL da página de destino.';
-          }
+const landingPageStep: WizardStep = {
+  id: 'landing_page_url',
+  title: 'Qual é a página de destino?',
+  description:
+    'Informe a URL principal onde as pessoas devem chegar após clicarem no anúncio.',
+  icon: LinkIcon,
+  validationRules: [
+    {
+      field: 'landing_page_url',
+      validate: value => {
+        const trimmedValue = value.trim();
+        if (!trimmedValue) {
+          return 'Informe a URL da página de destino.';
+        }
 
-          try {
-            const parsedUrl = new URL(trimmedValue);
-            if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-              return 'Utilize URLs iniciadas com http:// ou https://';
-            }
-          } catch (error) {
-            return 'Digite uma URL válida, incluindo http(s)://';
+        try {
+          const parsedUrl = new URL(trimmedValue);
+          if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+            return 'Utilize URLs iniciadas com http:// ou https://';
           }
+        } catch (error) {
+          return 'Digite uma URL válida, incluindo http(s)://';
+        }
 
+        return null;
+      },
+    },
+  ],
+};
+
+const nomeEmpresaStep: WizardStep = {
+  id: 'nome_empresa',
+  title: 'Qual é o nome da empresa?',
+  description: 'Informe como a marca deve ser citada nos criativos e mensagens.',
+  icon: Building2,
+  validationRules: [
+    {
+      field: 'nome_empresa',
+      validate: value => {
+        const trimmed = value.trim();
+        if (!trimmed) {
+          return 'Informe o nome da empresa ou marca.';
+        }
+        if (trimmed.length < 2) {
+          return 'Use ao menos 2 caracteres para o nome da empresa.';
+        }
+        if (trimmed.length > 100) {
+          return 'O nome da empresa deve ter no máximo 100 caracteres.';
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+const descricaoEmpresaStep: WizardStep = {
+  id: 'o_que_a_empresa_faz',
+  title: 'O que a empresa oferece?',
+  description:
+    'Descreva a proposta de valor ou principais serviços de forma objetiva.',
+  icon: Briefcase,
+  validationRules: [
+    {
+      field: 'o_que_a_empresa_faz',
+      validate: value => {
+        const trimmed = value.trim();
+        if (!trimmed) {
+          return 'Explique brevemente o que a empresa faz.';
+        }
+        if (trimmed.length < 10) {
+          return 'Use pelo menos 10 caracteres para descrever a empresa.';
+        }
+        if (trimmed.length > 200) {
+          return 'Resuma a descrição em até 200 caracteres.';
+        }
+        return null;
+      },
+    },
+  ],
+};
+
+const objetivoStep: WizardStep = {
+  id: 'objetivo_final',
+  title: 'Qual é o objetivo principal?',
+  description: 'Escolha o resultado desejado para medir o sucesso da campanha.',
+  icon: Target,
+  validationRules: [
+    {
+      field: 'objetivo_final',
+      validate: value => {
+        if (!value.trim()) {
+          return 'Selecione um objetivo para a campanha.';
+        }
+
+        if (!objetivoValues.has(value)) {
+          return 'Escolha um objetivo disponível na lista.';
+        }
+
+        return null;
+      },
+    },
+  ],
+};
+
+const formatoStep: WizardStep = {
+  id: 'formato_anuncio',
+  title: 'Qual formato será utilizado?',
+  description:
+    'Selecione o formato que melhor se adapta ao criativo e ao canal escolhido.',
+  icon: Layout,
+  validationRules: [
+    {
+      field: 'formato_anuncio',
+      validate: value => {
+        if (!value.trim()) {
+          return 'Selecione um formato de anúncio.';
+        }
+
+        if (!formatoValues.has(value)) {
+          return 'Escolha um formato válido.';
+        }
+
+        return null;
+      },
+    },
+  ],
+};
+
+const perfilStep: WizardStep = {
+  id: 'perfil_cliente',
+  title: 'Descreva o público ideal',
+  description: 'Resuma quem é o cliente ideal, dores, desejos e comportamentos.',
+  icon: Users,
+  validationRules: [
+    {
+      field: 'perfil_cliente',
+      validate: value => {
+        const trimmed = value.trim();
+        if (!trimmed) {
+          return 'Descreva brevemente o público do anúncio.';
+        }
+
+        if (trimmed.length < 20) {
+          return 'Use pelo menos 20 caracteres para detalhar o público.';
+        }
+
+        if (trimmed.length > 500) {
+          return 'Resuma o perfil em no máximo 500 caracteres.';
+        }
+
+        return null;
+      },
+    },
+  ],
+};
+
+const sexoClienteStep: WizardStep = {
+  id: 'sexo_cliente_alvo',
+  title: 'Existe um gênero predominante?',
+  description:
+    'Selecione caso haja comunicação direcionada a um gênero específico (opcional).',
+  icon: Venus,
+  isOptional: true,
+  validationRules: [
+    {
+      field: 'sexo_cliente_alvo',
+      validate: value => {
+        const trimmed = value.trim();
+        if (!trimmed) {
           return null;
-        },
+        }
+        if (!sexoClienteValues.has(trimmed)) {
+          return 'Escolha entre masculino, feminino ou neutro.';
+        }
+        return null;
       },
-    ],
-  },
-  {
-    id: 'nome_empresa',
-    title: 'Qual é o nome da empresa?',
-    subtitle: 'Passo 2',
-    description: 'Informe como a marca deve ser citada nos criativos e mensagens.',
-    icon: Building2,
-    validationRules: [
-      {
-        field: 'nome_empresa',
-        validate: value => {
-          const trimmed = value.trim();
-          if (!trimmed) {
-            return 'Informe o nome da empresa ou marca.';
-          }
-          if (trimmed.length < 2) {
-            return 'Use ao menos 2 caracteres para o nome da empresa.';
-          }
-          if (trimmed.length > 100) {
-            return 'O nome da empresa deve ter no máximo 100 caracteres.';
-          }
-          return null;
-        },
-      },
-    ],
-  },
-  {
-    id: 'o_que_a_empresa_faz',
-    title: 'O que a empresa oferece?',
-    subtitle: 'Passo 3',
-    description: 'Descreva a proposta de valor ou principais serviços de forma objetiva.',
-    icon: Briefcase,
-    validationRules: [
-      {
-        field: 'o_que_a_empresa_faz',
-        validate: value => {
-          const trimmed = value.trim();
-          if (!trimmed) {
-            return 'Explique brevemente o que a empresa faz.';
-          }
-          if (trimmed.length < 10) {
-            return 'Use pelo menos 10 caracteres para descrever a empresa.';
-          }
-          if (trimmed.length > 200) {
-            return 'Resuma a descrição em até 200 caracteres.';
-          }
-          return null;
-        },
-      },
-    ],
-  },
-  {
-    id: 'objetivo_final',
-    title: 'Qual é o objetivo principal?',
-    subtitle: 'Passo 4',
-    description: 'Escolha o resultado desejado para medir o sucesso da campanha.',
-    icon: Target,
-    validationRules: [
-      {
-        field: 'objetivo_final',
-        validate: value => {
-          if (!value.trim()) {
-            return 'Selecione um objetivo para a campanha.';
-          }
+    },
+  ],
+};
 
-          if (!objetivoValues.has(value)) {
-            return 'Escolha um objetivo disponível na lista.';
-          }
+const focoStep: WizardStep = {
+  id: 'foco',
+  title: 'Algum foco específico?',
+  description:
+    'Compartilhe diferenciais, promoções ou mensagens obrigatórias (opcional).',
+  icon: Sparkles,
+  isOptional: true,
+  validationRules: [
+    {
+      field: 'foco',
+      validate: () => null,
+    },
+  ],
+};
 
-          return null;
-        },
-      },
-    ],
-  },
-  {
-    id: 'formato_anuncio',
-    title: 'Qual formato será utilizado?',
-    subtitle: 'Passo 5',
-    description: 'Selecione o formato que melhor se adapta ao criativo e ao canal escolhido.',
-    icon: Layout,
-    validationRules: [
-      {
-        field: 'formato_anuncio',
-        validate: value => {
-          if (!value.trim()) {
-            return 'Selecione um formato de anúncio.';
-          }
+const reviewStep: WizardStep = {
+  id: 'review',
+  title: 'Revise antes de gerar',
+  description:
+    'Confira os dados informados e edite qualquer etapa antes de gerar os anúncios.',
+  icon: CheckCircle,
+};
 
-          if (!formatoValues.has(value)) {
-            return 'Escolha um formato válido.';
-          }
-
-          return null;
-        },
-      },
-    ],
-  },
-  {
-    id: 'perfil_cliente',
-    title: 'Descreva o público ideal',
-    subtitle: 'Passo 6',
-    description: 'Resuma quem é o cliente ideal, dores, desejos e comportamentos.',
-    icon: Users,
-    validationRules: [
-      {
-        field: 'perfil_cliente',
-        validate: value => {
-          const trimmed = value.trim();
-          if (!trimmed) {
-            return 'Descreva brevemente o público do anúncio.';
-          }
-
-          if (trimmed.length < 20) {
-            return 'Use pelo menos 20 caracteres para detalhar o público.';
-          }
-
-          if (trimmed.length > 500) {
-            return 'Resuma o perfil em no máximo 500 caracteres.';
-          }
-
-          return null;
-        },
-      },
-    ],
-  },
-  {
-    id: 'sexo_cliente_alvo',
-    title: 'Existe um gênero predominante?',
-    subtitle: 'Passo 7',
-    description: 'Selecione caso haja comunicação direcionada a um gênero específico (opcional).',
-    icon: Venus,
-    isOptional: true,
-    validationRules: [
-      {
-        field: 'sexo_cliente_alvo',
-        validate: value => {
-          const trimmed = value.trim();
-          if (!trimmed) {
-            return null;
-          }
-          if (!sexoClienteValues.has(trimmed)) {
-            return 'Escolha entre masculino, feminino ou neutro.';
-          }
-          return null;
-        },
-      },
-    ],
-  },
-  {
-    id: 'foco',
-    title: 'Algum foco específico?',
-    subtitle: 'Passo 8',
-    description: 'Compartilhe diferenciais, promoções ou mensagens obrigatórias (opcional).',
-    icon: Sparkles,
-    isOptional: true,
-    validationRules: [
-      {
-        field: 'foco',
-        validate: () => null,
-      },
-    ],
-  },
-  {
-    id: 'review',
-    title: 'Revise antes de gerar',
-    subtitle: 'Passo 9',
-    description: 'Confira os dados informados e edite qualquer etapa antes de gerar os anúncios.',
-    icon: CheckCircle,
-  },
+const orderedSteps: WizardStep[] = [
+  landingPageStep,
+  ...(enableNewFields ? [nomeEmpresaStep, descricaoEmpresaStep] : []),
+  objetivoStep,
+  formatoStep,
+  perfilStep,
+  ...(enableNewFields ? [sexoClienteStep] : []),
+  focoStep,
+  reviewStep,
 ];
+
+export const WIZARD_STEPS: WizardStep[] = orderedSteps.map((step, index) => ({
+  ...step,
+  subtitle: `Passo ${index + 1}`,
+}));
+

--- a/frontend/tests/steps.test.tsx
+++ b/frontend/tests/steps.test.tsx
@@ -11,7 +11,14 @@ describe('Wizard steps', () => {
   it('renders company name step', () => {
     expect(() =>
       renderToString(
-        <CompanyInfoStep variant="name" value="Empresa" onChange={noop} error={undefined} />,
+        <CompanyInfoStep
+          field="nome_empresa"
+          value="Empresa"
+          error={undefined}
+          touched={false}
+          onChange={noop}
+          onBlur={noop}
+        />,
       ),
     ).not.toThrow();
   });
@@ -20,10 +27,12 @@ describe('Wizard steps', () => {
     expect(() =>
       renderToString(
         <CompanyInfoStep
-          variant="description"
+          field="o_que_a_empresa_faz"
           value="Consultoria especializada"
-          onChange={noop}
           error={undefined}
+          touched={false}
+          onChange={noop}
+          onBlur={noop}
         />,
       ),
     ).not.toThrow();
@@ -32,7 +41,13 @@ describe('Wizard steps', () => {
   it('renders gender target step', () => {
     expect(() =>
       renderToString(
-        <GenderTargetStep value="masculino" onChange={noop} error={undefined} />,
+        <GenderTargetStep
+          value="masculino"
+          error={undefined}
+          touched={false}
+          onChange={noop}
+          onBlur={noop}
+        />,
       ),
     ).not.toThrow();
   });

--- a/frontend/tests/wizard.utils.test.ts
+++ b/frontend/tests/wizard.utils.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { formatSubmitPayload } from '@/utils/wizard.utils';
-import { WIZARD_INITIAL_STATE } from '@/constants/wizard.constants';
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
 
 describe('formatSubmitPayload', () => {
-  it('includes new fields when provided', () => {
+  it('includes new fields when provided', async () => {
+    vi.stubEnv('VITE_ENABLE_NEW_FIELDS', 'true');
+    const { formatSubmitPayload } = await import('@/utils/wizard.utils');
+    const { WIZARD_INITIAL_STATE } = await import('@/constants/wizard.constants');
+
     const state = {
       ...WIZARD_INITIAL_STATE,
       landing_page_url: 'https://example.com',
@@ -26,7 +32,11 @@ describe('formatSubmitPayload', () => {
     expect(payload).toContain('sexo_cliente_alvo: masculino');
   });
 
-  it('applies neutro default when gender is empty', () => {
+  it('applies neutro default when gender is empty', async () => {
+    vi.stubEnv('VITE_ENABLE_NEW_FIELDS', 'true');
+    const { formatSubmitPayload } = await import('@/utils/wizard.utils');
+    const { WIZARD_INITIAL_STATE } = await import('@/constants/wizard.constants');
+
     const state = {
       ...WIZARD_INITIAL_STATE,
       landing_page_url: 'https://example.com',

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -38,21 +38,26 @@ class DummyStorageClient:
 
 
 @pytest.fixture
-def preflight_client(monkeypatch):
-    monkeypatch.setattr('google.auth.default', lambda *args, **kwargs: (None, 'test-project'))
-    monkeypatch.setattr('google.cloud.logging.Client', DummyLoggingClient)
-    monkeypatch.setattr('google.cloud.storage.Client', DummyStorageClient)
+def preflight_client_factory(monkeypatch):
+    def _create(*, enable_new_fields: bool, shadow_mode: bool):
+        monkeypatch.setenv('ENABLE_NEW_INPUT_FIELDS', 'true' if enable_new_fields else 'false')
+        monkeypatch.setenv('PREFLIGHT_SHADOW_MODE', 'true' if shadow_mode else 'false')
+        monkeypatch.setattr('google.auth.default', lambda *args, **kwargs: (None, 'test-project'))
+        monkeypatch.setattr('google.cloud.logging.Client', DummyLoggingClient)
+        monkeypatch.setattr('google.cloud.storage.Client', DummyStorageClient)
 
-    sys.modules.pop('app.server', None)
-    import app.server as server
+        sys.modules.pop('app.server', None)
+        import app.server as server
 
-    server = reload(server)
-    client = TestClient(server.app)
-    return client, server
+        server = reload(server)
+        client = TestClient(server.app)
+        return client, server
+
+    return _create
 
 
-def test_preflight_includes_new_fields(preflight_client, monkeypatch):
-    client, server = preflight_client
+def test_preflight_includes_new_fields(preflight_client_factory, monkeypatch):
+    client, server = preflight_client_factory(enable_new_fields=True, shadow_mode=False)
 
     def fake_extract_user_input(_text):
         return {
@@ -87,8 +92,8 @@ def test_preflight_includes_new_fields(preflight_client, monkeypatch):
     assert initial_state['sexo_cliente_alvo'] == 'masculino'
 
 
-def test_preflight_uses_defaults_for_missing_fields(preflight_client, monkeypatch):
-    client, server = preflight_client
+def test_preflight_uses_defaults_for_missing_fields(preflight_client_factory, monkeypatch):
+    client, server = preflight_client_factory(enable_new_fields=True, shadow_mode=False)
 
     def fake_extract_user_input(_text):
         return {
@@ -121,3 +126,38 @@ def test_preflight_uses_defaults_for_missing_fields(preflight_client, monkeypatc
     assert initial_state['nome_empresa'] == 'Empresa'
     assert initial_state['o_que_a_empresa_faz'] == ''
     assert initial_state['sexo_cliente_alvo'] == 'neutro'
+
+
+def test_preflight_excludes_new_fields_when_disabled(preflight_client_factory, monkeypatch):
+    client, server = preflight_client_factory(enable_new_fields=False, shadow_mode=False)
+
+    def fake_extract_user_input(_text):
+        return {
+            'success': True,
+            'data': {
+                'landing_page_url': 'https://example.com',
+                'objetivo_final': 'agendamentos',
+                'perfil_cliente': 'clientes em potencial',
+                'formato_anuncio': 'Reels',
+                'nome_empresa': 'Empresa Teste',
+                'o_que_a_empresa_faz': 'Consultoria em marketing',
+                'sexo_cliente_alvo': 'feminino',
+            },
+            'normalized': {
+                'formato_anuncio_norm': 'Reels',
+                'objetivo_final_norm': 'agendamentos',
+                'sexo_cliente_alvo_norm': 'feminino',
+            },
+            'errors': [],
+        }
+
+    monkeypatch.setattr(server, 'extract_user_input', fake_extract_user_input)
+
+    response = client.post('/run_preflight', json={'text': 'dummy'})
+    assert response.status_code == 200
+    payload = response.json()
+
+    initial_state = payload['initial_state']
+    assert 'nome_empresa' not in initial_state
+    assert 'o_que_a_empresa_faz' not in initial_state
+    assert 'sexo_cliente_alvo' not in initial_state

--- a/tests/unit/test_user_extract_data.py
+++ b/tests/unit/test_user_extract_data.py
@@ -32,7 +32,9 @@ def patch_langextract(monkeypatch):
     return _apply
 
 
-def test_extract_user_input_returns_new_fields(patch_langextract):
+def test_extract_user_input_returns_new_fields(patch_langextract, monkeypatch):
+    monkeypatch.setenv('ENABLE_NEW_INPUT_FIELDS', 'true')
+    monkeypatch.setenv('PREFLIGHT_SHADOW_MODE', 'false')
     patch_langextract(
         [
             DummyExtraction("landing_page_url", "https://example.com"),
@@ -56,7 +58,9 @@ def test_extract_user_input_returns_new_fields(patch_langextract):
     assert result["normalized"]["sexo_cliente_alvo_norm"] == "feminino"
 
 
-def test_extract_user_input_gender_default_neutro(patch_langextract):
+def test_extract_user_input_gender_default_neutro(patch_langextract, monkeypatch):
+    monkeypatch.setenv('ENABLE_NEW_INPUT_FIELDS', 'true')
+    monkeypatch.setenv('PREFLIGHT_SHADOW_MODE', 'false')
     patch_langextract(
         [
             DummyExtraction("landing_page_url", "https://example.com"),
@@ -71,5 +75,5 @@ def test_extract_user_input_gender_default_neutro(patch_langextract):
     result = extract_user_input("dummy text")
 
     assert result["normalized"]["sexo_cliente_alvo_norm"] == "neutro"
-    assert result["data"].get("sexo_cliente_alvo") is None
+    assert result["data"].get("sexo_cliente_alvo") == "neutro"
     assert result["success"] is True


### PR DESCRIPTION
## Summary
- gate the extractor prompt and conversion flow behind ENABLE_NEW_INPUT_FIELDS/PREFLIGHT_SHADOW_MODE while keeping defaults for the rollout path
- conditionally inject the new company fields into preflight state and logging with a shadow-mode metric
- wrap the wizard extras behind VITE_ENABLE_NEW_FIELDS, update step components to use touched/onBlur props and refresh unit tests

## Testing
- make lint *(fails: codespell flags Portuguese documentation)*
- make test *(unit suite passes; integration fails because sa-key.json credentials are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d0c0159083219f885b7665b19f7f