### PR TITLE
docs: document landing page stage behavior

### DIFF
--- a/docs/storybrand_fallback.md
+++ b/docs/storybrand_fallback.md
@@ -35,6 +35,9 @@ Principais arquivos:
 - `FALLBACK_STORYBRAND_MAX_ITERATIONS` controla o número máximo de tentativas por seção (default: 3).
 - `FALLBACK_STORYBRAND_MODEL` permite definir um modelo dedicado (default usa `config.worker_model`).
 - `STORYBRAND_GATE_DEBUG` força o fallback para QA.
+- Quando o fallback é forçado (via `storybrand_gate_debug` ou `force_storybrand_fallback` com flags habilitadas), a etapa de
+  análise da landing page é ignorada e o pipeline começa diretamente pelo fallback, mantendo `landing_page_context` como um
+  dicionário vazio para auditoria.
 
 ## Testes
 - `tests/unit/agents/test_storybrand_gate.py` cobre decisões do gate (score alto/baixo, force flag, flags desabilitadas).

--- a/docs/storybrand_landing_page_flow.md
+++ b/docs/storybrand_landing_page_flow.md
@@ -1,0 +1,13 @@
+# StoryBrand Landing Page Flow
+
+## Estado atual (commit 47e6f5e)
+- O pipeline `complete_pipeline` executa `LandingPageStage` antes do `StoryBrandQualityGate`. O wrapper chama o agente real de landing page apenas quando o fallback não está sendo forçado. Caso as flags `ENABLE_STORYBRAND_FALLBACK`, `ENABLE_NEW_INPUT_FIELDS` e `STORYBRAND_GATE_DEBUG` ou o sinal `force_storybrand_fallback` estejam ativos, ele preenche `landing_page_context` com `{}` e registra `storybrand_landing_page_skipped` sem coletar dados da landing page.
+- Após o estágio condicional, `StoryBrandQualityGate` decide se roda o fallback (sempre que o forçamento está habilitado ou o score está ausente/abaixo do mínimo) e em seguida delega para o planejador normal.
+
+## Estado anterior (commit 53f1b9c)
+- O mesmo `complete_pipeline` chamava `landing_page_analyzer` diretamente. Mesmo quando o gate entrava em modo debug/forçado, a análise da landing page era executada antes do fallback.
+- As decisões do `StoryBrandQualityGate` já honravam as flags (`ENABLE_STORYBRAND_FALLBACK`, `ENABLE_NEW_INPUT_FIELDS`, `STORYBRAND_GATE_DEBUG`, `force_storybrand_fallback`), mas como a análise vinha antes do gate, o fallback “forçado” ainda consumia os recursos da etapa de landing page.
+
+> Referências diretas:
+> - commit 47e6f5ea8b96c98717c636d087788aa3d50b6546 (`app/agent.py`, linhas 692-724 e 1270-1278).
+> - commit 53f1b9c246a47e599859fdd260f5d8d0d164e7a0 (`app/agent.py`, linhas 1233-1240).

--- a/tests/unit/agents/test_landing_page_stage.py
+++ b/tests/unit/agents/test_landing_page_stage.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+import pytest
+from google.adk.events import Event
+
+from app.agent import LandingPageStage
+from app.config import config
+
+
+class DummyLandingPageAgent:
+    def __init__(self) -> None:
+        self.called = False
+
+    async def run_async(self, ctx):
+        self.called = True
+        yield Event(author="dummy_landing_agent")
+
+
+def make_ctx(state=None):
+    state = state or {}
+    session = SimpleNamespace(state=state)
+    return SimpleNamespace(session=session)
+
+
+@pytest.mark.asyncio
+async def test_landing_page_stage_skips_when_debug_forces(monkeypatch):
+    monkeypatch.setattr(config, "enable_storybrand_fallback", True)
+    monkeypatch.setattr(config, "enable_new_input_fields", True)
+    monkeypatch.setattr(config, "storybrand_gate_debug", True)
+
+    dummy = DummyLandingPageAgent()
+    stage = LandingPageStage(landing_page_agent=dummy)
+
+    ctx = make_ctx()
+
+    events = []
+    async for event in stage._run_async_impl(ctx):
+        events.append(event)
+
+    assert events == []
+    assert dummy.called is False
+    assert isinstance(ctx.session.state.get("landing_page_context"), dict)
+
+
+@pytest.mark.asyncio
+async def test_landing_page_stage_skips_when_force_flag(monkeypatch):
+    monkeypatch.setattr(config, "enable_storybrand_fallback", True)
+    monkeypatch.setattr(config, "enable_new_input_fields", True)
+    monkeypatch.setattr(config, "storybrand_gate_debug", False)
+
+    dummy = DummyLandingPageAgent()
+    stage = LandingPageStage(landing_page_agent=dummy)
+
+    ctx = make_ctx({"force_storybrand_fallback": True})
+
+    events = []
+    async for event in stage._run_async_impl(ctx):
+        events.append(event)
+
+    assert events == []
+    assert dummy.called is False
+    assert isinstance(ctx.session.state.get("landing_page_context"), dict)
+
+
+@pytest.mark.asyncio
+async def test_landing_page_stage_runs_agent_when_not_forced(monkeypatch):
+    monkeypatch.setattr(config, "enable_storybrand_fallback", True)
+    monkeypatch.setattr(config, "enable_new_input_fields", True)
+    monkeypatch.setattr(config, "storybrand_gate_debug", False)
+
+    dummy = DummyLandingPageAgent()
+    stage = LandingPageStage(landing_page_agent=dummy)
+
+    ctx = make_ctx()
+
+    events = []
+    async for event in stage._run_async_impl(ctx):
+        events.append(event)
+
+    assert dummy.called is True
+    assert events and events[0].author == "dummy_landing_agent"


### PR DESCRIPTION
## Summary
- add documentation clarifying how the LandingPageStage gates the landing page analyzer when StoryBrand fallback is forced
- record the previous pipeline behavior for comparison with the new conditional stage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9ab0831b083219ed2fa6fe11ea1ec