### PR TITLE
feat: enrich deterministic validation observability

### DIFF
--- a/app/agents/storybrand_gate.py
+++ b/app/agents/storybrand_gate.py
@@ -46,6 +46,9 @@ class StoryBrandQualityGate(BaseAgent):
 
     async def _run_async_impl(self, ctx: InvocationContext) -> AsyncGenerator[Event, None]:  # type: ignore[override]
         state = ctx.session.state
+        state.setdefault("storybrand_audit_trail", [])
+        state.setdefault("storybrand_gate_metrics", {})
+        state.setdefault("storybrand_fallback_meta", {})
         threshold = getattr(config, "min_storybrand_completeness", 0.0)
         score = _extract_score(state)
         fallback_enabled = bool(getattr(config, "enable_storybrand_fallback", False) and getattr(config, "enable_new_input_fields", False))

--- a/app/callbacks/landing_page_callbacks.py
+++ b/app/callbacks/landing_page_callbacks.py
@@ -58,6 +58,7 @@ def _mark_storybrand_failure(
         reason=reason,
         message=message,
         extra={"retry_after": retry_after, "attempts": attempts},
+        state=state,
     )
     record_delivery_failure(reason)
 

--- a/app/validators/final_delivery_validator.py
+++ b/app/validators/final_delivery_validator.py
@@ -213,5 +213,6 @@ class FinalDeliveryValidatorAgent(BaseAgent):
             reason="deterministic_final_validation_failed",
             message=failure_message,
             extra=extra,
+            state=state,
         )
 

--- a/checklist_plano_json_v3.md
+++ b/checklist_plano_json_v3.md
@@ -57,11 +57,13 @@
 > Notas Fase 3: Pipeline determinístico reconstruído com guard/normalizer, `build_execution_pipeline` entrega caminhos independentes e gating sequencial (`RunIfPassed`) cobre revisão semântica, imagens e persistência. Guard e normalizer alimentam `deterministic_final_validation`; `ImageAssetsAgent` fornece `image_assets_review` com suporte a `grade="skipped"` e persistência fica centralizada no novo agente.
 
 ## 4. Fase 4 – Observabilidade e Persistência
-- [ ] Modificar `make_failure_handler` em `app/agent.py` para suportar chaves determinísticas sem sobrescrever fluxo legado.
-- [ ] Atualizar `write_failure_meta`/`clear_failure_meta` em `app/utils/delivery_status.py` para incluir `deterministic_final_validation`, `semantic_visual_review`, `image_assets_review`.
-- [ ] Ajustar `persist_final_delivery` (`app/callbacks/persist_outputs.py`) para gravar JSON normalizado, limpar chaves legadas e popular `state['final_delivery_status']` com origem determinística.
-- [ ] Garantir preenchimento consistente de `state['storybrand_audit_trail']`, `state['storybrand_gate_metrics']`, `state['storybrand_fallback_meta']` e novos eventos de auditoria determinística.
-- [ ] Atualizar `EnhancedStatusReporter` e endpoints `/delivery/final/*` para exibir status determinístico sem quebrar consumidores existentes.
+- [x] Modificar `make_failure_handler` em `app/agent.py` para suportar chaves determinísticas sem sobrescrever fluxo legado.
+- [x] Atualizar `write_failure_meta`/`clear_failure_meta` em `app/utils/delivery_status.py` para incluir `deterministic_final_validation`, `semantic_visual_review`, `image_assets_review`.
+- [x] Ajustar `persist_final_delivery` (`app/callbacks/persist_outputs.py`) para gravar JSON normalizado, limpar chaves legadas e popular `state['final_delivery_status']` com origem determinística.
+- [x] Garantir preenchimento consistente de `state['storybrand_audit_trail']`, `state['storybrand_gate_metrics']`, `state['storybrand_fallback_meta']` e novos eventos de auditoria determinística.
+- [x] Atualizar `EnhancedStatusReporter` e endpoints `/delivery/final/*` para exibir status determinístico sem quebrar consumidores existentes.
+
+> Notas Fase 4: Flags de falha agora usam handler extensível, metadados persistidos incluem snapshots das revisões (determinística, semântica e imagens) e status finais incorporam métricas/auditoria StoryBrand. Persistência grava payload normalizado, limpa artefatos legados e enriquece meta/endpoints com o estágio atual.
 
 ## 5. Fase 5 – Testes Automatizados & QA
 ### 5.1 Testes unitários


### PR DESCRIPTION
## Summary
- extend `make_failure_handler` and status reporter messaging to surface deterministic validation outcomes without breaking legacy flows
- persist failure metadata and final delivery artifacts with normalized payloads, review snapshots, and StoryBrand context while clearing stale flags
- ensure StoryBrand gate initializes audit state, update checklist, and expand unit coverage for delivery status helpers

## Testing
- uv run pytest tests/unit/utils/test_delivery_status.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ce0929948321b346c607eb708675