### PR TITLE
docs: alinhar imagem_roupa com diretrizes de referências visuais

### DIFF
--- a/imagem_roupa.md
+++ b/imagem_roupa.md
@@ -1,9 +1,28 @@
 # Plano Estendido — Referências Visuais de Personagem e Produto/Serviço
 
 ## 0. Visão Geral & Metas
-- **Objetivo**: habilitar uploads opcionais de imagens de personagem e produto/serviço, reaproveitando os metadados (SafeSearch + labels) em todo o pipeline de geração de anúncios (copy + visual + imagens finais).
-- **Abordagem**: introduzir novos schemas e cache compartilhado, estender endpoints/backend e atualizar agentes e prompts, mantendo compatibilidade quando nenhuma referência for enviada.
-- **Princípios chave**: distinguir entregas novas vs. código existente, garantir sanitização de dados sensíveis e cobrir o fluxo completo com testes automatizados.
+- **Contexto ampliado**: referências visuais enviadas pelos anunciantes são opcionais, mas quando aprovadas pelo fluxo automático (Google SafeSearch) precisam ser consumidas obrigatoriamente por todos os agentes responsáveis por prompt, geração visual e montagem do pacote final. O plano deve deixar inequívoco como essas condicionais funcionam para evitar interpretações diferentes entre implementadores.
+- **Objetivo**: habilitar uploads opcionais de imagens de personagem e produto/serviço, reaproveitando os metadados (SafeSearch + labels) em todo o pipeline de geração de anúncios (copy + visual + imagens finais), garantindo diferenciação clara dos prompts conforme a disponibilidade de cada referência.
+- **Abordagem**: introduzir novos schemas e cache compartilhado, estender endpoints/backend e atualizar agentes e prompts, mantendo compatibilidade quando nenhuma referência for enviada e reforçando políticas de uso obrigatório após aprovação.
+- **Cenários suportados**:
+  - `Cenário A – sem referências`: manter comportamento atual sem placeholders ou instruções adicionais.
+  - `Cenário B – apenas personagem`: instruir os prompts a mencionar explicitamente o personagem aprovado, preservando características físicas e permitindo alteração de expressão facial conforme diretrizes do ADK.
+  - `Cenário C – apenas produto/serviço`: enfatizar atributos do produto real usando labels/descrições aprovadas, sem menções ao personagem.
+  - `Cenário D – personagem e produto`: combinar ambos os resumos garantindo coerência narrativa entre copy e visual.
+- **Política de uso obrigatório**: qualquer referência liberada pelo SafeSearch deve ser registrada no cache, aplicada nos prompts (`VISUAL_DRAFT`, `COPY_DRAFT`, `final_assembler`) e refletida no `visual.reference_assets`. Rejeições precisam ser logadas, e o plano documenta como proceder para manter o fluxo sem referências.
+- **Compromissos de prompting**: quando `reference_image_character_summary` existir, os prompts devem incluir instruções que preservem aparência (tom de pele, cabelo, formato do rosto), mencionem o personagem pelo nome/descrição fornecida e liberem mudança de expressão facial em função do comando do ADK para cada imagem sequencial.
+- **Indicadores de sucesso**: QA (automático e manual) deve comprovar que prompts finais mencionam explicitamente a presença do personagem quando disponível, que mudanças de expressão solicitadas se refletem nos comandos enviados aos modelos e que a ausência de referências não introduz regressões.
+
+### Diagnóstico inicial
+Para orientar as próximas fases, foi realizada uma análise estruturada do documento vigente seguindo o procedimento descrito em `plano_atualizacao_imagem_roupa.md`. As lacunas mapeadas foram agrupadas em três categorias principais.
+
+| Seção | Descrição da lacuna | Categoria | Impacto esperado | Prioridade de correção |
+|-------|----------------------|-----------|------------------|------------------------|
+| Visão Geral & Metas | Não havia menção explícita aos quatro cenários de uso (0/1/2 referências) nem orientação sobre obrigatoriedade pós-aprovação. | Opcionalidade | Stakeholders podem presumir comportamento sempre obrigatório ou sempre ausente, gerando implementação inconsistente. | Alta |
+| Fase 4 – Pipeline de Agents & Prompts | Diretrizes de prompting não diferenciavam personagem vs. produto, tampouco davam instruções sobre preservação de aparência ou mudança de expressão. | Adaptação de expressão/prompt | Risco de o ADK gerar imagens inconsistentes com o personagem enviado ou ignorar o ativo. | Alta |
+| Fase 6 – Testes Automatizados & QA | Critérios de QA não exigiam evidências de uso obrigatório após aprovação nem testes específicos para expressões faciais. | Uso obrigatório pós-aprovação | Cobertura de testes insuficiente para detectar regressões no pipeline visual. | Média |
+
+> Metodologia: leitura sequencial de `imagem_roupa.md`, classificação das lacunas em `Opcionalidade`, `Uso obrigatório pós-aprovação` e `Adaptação de expressão/prompt`, seguida de confrontação com os requisitos adicionais fornecidos pelo usuário nesta conversa.
 
 ---
 ## Fase 1 – Schemas e Cache de Referências
@@ -49,7 +68,7 @@
 - Modificar `run_preflight` em `app/server.py:163-395`:
   - Reutilizar `RunPreflightRequest`.
   - Resolver metadados via `resolve_reference_metadata` (criada na Fase 1).
-  - Construir `initial_state["reference_images"]`, `reference_image_summary`, `reference_image_character_summary`, `reference_image_product_summary`.
+  - Construir `initial_state["reference_images"]`, `reference_image_summary`, `reference_image_character_summary`, `reference_image_product_summary` e `reference_image_safe_search_notes` para diferenciar motivos de reprovação.
   - Devolver `initial_state` enriquecido sem manipulações externas.
 - Registrar logs estruturados (`logger.log_struct`) para uploads e preflight.
 
@@ -117,46 +136,70 @@
 ---
 ## Fase 4 – Integração no Pipeline de Agents & Prompts
 
+### Objetivo revisado
+Detalhar, na própria descrição do pipeline, como os agentes devem consumir dados de referências visuais e como os prompts se adaptam a cada cenário, mantendo compatibilidade com as instruções determinísticas já estabelecidas para `code_generator`, `code_reviewer` e `code_refiner`.
+
+#### 4.1 Placeholders e estrutura de dados
+- Atualizar prompts em `app/agent.py` para incluir placeholders condicionais derivados da Fase 2:
+  - **VISUAL_DRAFT** (linhas ~880-930): `{reference_image_character_summary}`, `{reference_image_product_summary}`, `{reference_image_safe_search_notes}`.
+  - **COPY_DRAFT** (linhas ~830-880): `{reference_image_product_summary}` e `{reference_image_character_summary}` quando relevantes para consistência narrativa.
+  - **final_assembler** (`app/agent.py:1030-1075`): injetar `reference_images.<type>.gcs_uri`, `.labels`, `.user_description` e preencher `visual.reference_assets` com metadados aprovados.
+- No `ImageAssetsAgent` (`app/agent.py:300-577`), reidratar `ReferenceImageMetadata` via `model_validate`, armazenar flags `character_reference_used` e `product_reference_used` e garantir que o summary exponha quando uma referência foi descartada por reprovação do SafeSearch.
+- Em `generate_transformation_images` (`app/tools/generate_transformation_images.py:180-330`), aceitar novos parâmetros opcionais para personagem/produto e centralizar carregamento de ativos no helper `_load_reference_image`.
+- Atualizar templates em `app/config.py` para introduzir `image_current_prompt_template` e `image_aspirational_prompt_template_with_product`, ativando-os apenas quando as referências correspondentes estiverem aprovadas.
+
+#### 4.2 Diretrizes de prompting para personagem
+- Instruir que sempre que `reference_images.character.status == "approved"`:
+  - Os prompts nomeiem ou descrevam o personagem com base no resumo aprovado.
+  - As características físicas (tom de pele, cabelo, traços faciais, vestimenta principal) sejam preservadas explicitamente em cada uma das três imagens sequenciais (`prompt_estado_atual`, `prompt_estado_intermediario`, `prompt_estado_aspiracional`).
+  - Seja adicionada instrução para permitir mudança de expressão facial conforme pedido pelo ADK: "render the same character now showing <emoção solicitada>".
+  - Logs do summary registrem qual emoção final foi aplicada em cada etapa.
+
+#### 4.3 Diretrizes quando apenas produto estiver presente
+- Se apenas `reference_images.product` estiver aprovado:
+  - Remover qualquer menção a personagem dos prompts, reforçando atributos do produto (labels, materiais, uso principal).
+  - Adaptar `COPY_DRAFT` para destacar diferenciais do produto real, mantendo coerência com as imagens.
+  - Documentar fallback textual que reitera que a narrativa deve focar no produto sem inventar personagens ausentes.
+
+#### 4.4 Cenários combinados e compatibilidade com instruções fixas
+- Quando ambos os ativos existirem, combinar resumos mantendo coerência (`personagem interage com produto`) e distribuir responsabilidades entre copy e visual.
+- Reafirmar que os agentes continuam produzindo exatamente três prompts sequenciais; os novos placeholders complementam, mas não substituem, `prompt_estado_atual`, `prompt_estado_intermediario` e `prompt_estado_aspiracional`.
+- Inserir nota explícita de que as instruções endurecidas dos agentes (`instrucoes_fixas_agentes.md`) permanecem válidas; quaisquer mudanças devem ser incrementais e não podem afrouxar os critérios de falha estabelecidos.
+
+#### 4.5 Quadro comparativo de prompts por cenário
+
+| Cenário | Diretrizes principais | Exemplo de instrução adicional |
+|---------|----------------------|--------------------------------|
+| Sem referências | Reutilizar prompts atuais sem placeholders extras. | "Gerar cena aspiracional padrão do ADK." |
+| Apenas personagem | Mencionar personagem, preservar aparência, permitir alteração de expressão. | "Use o personagem descrito em `{reference_image_character_summary}` mantendo cabelo cacheado, agora mostrando expressão de surpresa." |
+| Apenas produto | Focar no produto real, remover menções a personagens inexistentes. | "Realce o tênis `{reference_image_product_summary}` em foco principal, sem incluir personagens." |
+| Personagem e produto | Combinar orientações anteriores garantindo interação coerente. | "Mostre o personagem `{reference_image_character_summary}` segurando o produto destacado, com expressão alegre conforme solicitado." |
+
+#### 4.6 Exemplo guiado (antes/depois) – adaptação de expressão
+```
+Antes (sem referência):
+- prompt_estado_atual: Render a customer trying the outfit in-store.
+
+Depois (com personagem aprovado pedindo expressão triste):
+- prompt_estado_atual: Render the same character from {reference_image_character_summary}, preserving facial features and hairstyle, now showing a sad expression while trying the outfit in-store.
+```
+
 ### Entregáveis
-- Atualizar prompts em `app/agent.py`:
-  - **VISUAL_DRAFT** (linhas ~880-930): adicionar placeholders `{reference_image_character_summary}` e `{reference_image_product_summary}` (criados na Fase 2) com instruções condicionais.
-  - **COPY_DRAFT** (linhas ~830-880): permitir menção ao produto real utilizando labels do cache.
-  - **final_assembler** (`app/agent.py:1030-1075`):
-    - Injetar `reference_images.character.gcs_uri`, `reference_images.character.labels`, `reference_images.product.gcs_uri`, `reference_images.product.labels`.
-    - Pós-processar saída para preencher `visual.reference_assets` com valores factuais quando presentes.
-- Atualizar `ImageAssetsAgent` (`app/agent.py:300-577`):
-  - Carregar `state["reference_images"]` (dicionários), reidratar com `ReferenceImageMetadata.model_validate` (criado na Fase 1).
-  - Registrar no summary flags `character_reference_used`, `product_reference_used`.
-- Estender `generate_transformation_images` (`app/tools/generate_transformation_images.py:180-330`):
-  - Novos parâmetros `reference_character: ReferenceImageMetadata | None` e `reference_product: ReferenceImageMetadata | None`.
-  - Helper `_load_reference_image(metadata: ReferenceImageMetadata) -> Image.Image`.
-  - Ajustar prompts de estágio atual/aspiracional quando referências estiverem presentes.
-- Atualizar templates em `app/config.py`:
-  - Criar novo template `image_current_prompt_template` e usar `image_aspirational_prompt_template_with_product` (novos) quando houver referências; manter `image_aspirational_prompt_template` existente para o fluxo legado sem referências.
+- Seção reescrita com subtítulos 4.1–4.6, placeholders condicionais e quadro comparativo cobrindo os quatro cenários.
+- Anexo de exemplo antes/depois incorporado, ilustrando mudança de expressão mantendo aparência.
+- Referência explícita à compatibilidade com as instruções fixas dos agentes e aos três prompts sequenciais.
 
 ### Dependências existentes
 - `ImageAssetsAgent` atual (`app/agent.py:300-577`).
 - Função `generate_transformation_images` (`app/tools/generate_transformation_images.py:180-330`).
 - Config `image_signed_url_ttl` declarada em `app/config.py:66` e sobrescrita via env em `app/config.py:143-144`.
-
-### Modificações planejadas (resumo)
-```diff
-# app/agent.py (final_assembler)
--    "visual": {..., "referencia_padroes": "..."}
-+    "visual": {...,
-+        "referencia_padroes": "...",
-+        "reference_assets": {
-+            "character": <valores do state>,
-+            "product": <valores do state>
-+        }
-+    }
-```
+- Instruções vigentes em `instrucoes_fixas_agentes.md` para `code_generator`, `code_reviewer` e `code_refiner`.
 
 ### Critérios de aceitação
-- [ ] Prompts utilizam placeholders condicionais; plano feliz sem referências permanece intacto.
-- [ ] `ImageAssetsAgent` gera flags de uso de referência e mantém fallback quando dados ausentes.
-- [ ] `generate_transformation_images` aceita novos parâmetros sem quebrar assinaturas existentes (ver testes Fase 6).
-- [ ] JSON final inclui `visual.reference_assets` apenas quando metadados existem.
+- [ ] Subtópicos 4.1–4.6 documentam preservação de aparência e mudança de expressão facial para personagem aprovado.
+- [ ] Tabela comparativa cobre os quatro cenários possíveis sem contradizer instruções existentes.
+- [ ] `ImageAssetsAgent`, `generate_transformation_images` e templates possuem orientação textual clara para uso obrigatório após aprovação.
+- [ ] Nota explícita assegura que os três prompts sequenciais e critérios de falha dos agentes permanecem válidos.
 
 ---
 ## Fase 5 – Observabilidade, Persistência e Sanitização
@@ -186,22 +229,24 @@
 ### Entregáveis
 - **Unit Tests**:
   - `tests/unit/utils/test_reference_cache.py` (cache, TTL, merge com descrições).
-  - `tests/unit/utils/test_vision.py` (mocks do SafeSearch e labels).
-  - `tests/unit/tools/test_generate_transformation_images.py` (parâmetros com referências vs. fallback).
-  - `tests/unit/agents/test_image_assets_agent.py` (reidratação de metadados e flags de summary).
-  - `tests/unit/callbacks/test_persist_outputs.py` (sanitização de `reference_images`).
+  - `tests/unit/utils/test_vision.py` (mocks do SafeSearch aprovando/reprovando e registrando notas utilizadas nos prompts).
+  - `tests/unit/tools/test_generate_transformation_images.py` (parâmetros com referências vs. fallback, verificando comandos de expressão facial por imagem sequencial).
+  - `tests/unit/agents/test_image_assets_agent.py` (reidratação de metadados, flags de summary e registro de emoções solicitadas).
+  - `tests/unit/callbacks/test_persist_outputs.py` (sanitização de `reference_images` e garantia de remoção de `signed_url`).
 - **Integração**:
-  - `tests/integration/api/test_reference_upload.py`: upload → análise → cache → `/run_preflight` recuperando metadados no `initial_state`.
-  - `tests/integration/agents/test_reference_pipeline.py`: pipeline parcial com referências, verificando JSON final e `reference_assets`.
+  - `tests/integration/api/test_reference_upload.py`: upload → análise → cache → `/run_preflight` recuperando metadados no `initial_state`, cobrindo respostas aprovadas e reprovadas do SafeSearch.
+  - `tests/integration/agents/test_reference_pipeline.py`: pipeline parcial com referências, verificando JSON final, `reference_assets` e presença dos comandos de expressão gerados em cada prompt sequencial.
 - **Frontend**:
-  - RTL tests para `ReferenceUpload` e `handleSubmit` com/sem uploads.
-  - Cenários Cypress (se suite existir) para formulário completo.
-- **QA manual**: roteiro com quatro cenários (nenhuma referência, apenas personagem, apenas produto, ambos) para validar UX e resultados.
+  - RTL tests para `ReferenceUpload` e `handleSubmit` com/sem uploads, cobrindo feedback ao usuário quando SafeSearch reprovar arquivos.
+  - Cenários Cypress (se suite existir) para formulário completo com evidência de envio condicional.
+- **QA manual**: roteiro com quatro cenários (nenhuma referência, apenas personagem, apenas produto, ambos) para validar UX e resultados, incluindo captura de screenshots/logs dos prompts com mudança de expressão (ex.: alegre → triste) e checklist de uso obrigatório.
+- **Evidências documentais**: criar pasta `artifacts/qa/reference-images` com exemplos antes/depois de prompts e imagens geradas, registrando emoção solicitada e resultado observado.
 
 ### Critérios de aceitação
-- [ ] `make test` cobre novas suites sem regressões.
-- [ ] Testes de integração validam ciclo completo (incluindo sanitização).
-- [ ] Roteiro manual documenta prints/logs de cada cenário.
+- [ ] `make test` cobre novas suites sem regressões e verifica comandos de expressão facial nos prompts.
+- [ ] Testes de integração validam ciclo completo (incluindo sanitização e branchs SafeSearch aprovado/reprovado).
+- [ ] Roteiro manual documenta prints/logs de cada cenário, evidenciando mudança de expressão quando personagem estiver disponível.
+- [ ] Pasta `artifacts/qa/reference-images` contém exemplos antes/depois aprovados pelo QA.
 
 ---
 ## Fase 7 – Documentação & Rollout
@@ -245,6 +290,14 @@
 - [ ] Plano pode ser validado pelo `plan-code-validator` sem falsos P0.
 
 ---
+## Resumo das Atualizações de Prompt
+- **Opcionalidade**: documentação agora enumera explicitamente os quatro cenários possíveis (nenhum, apenas personagem, apenas produto, ambos) e descreve o comportamento esperado em cada fase, assegurando que uploads continuem opcionais.
+- **Uso obrigatório pós-aprovação**: reforços textuais determinam que referências aprovadas pelo SafeSearch devem aparecer nos prompts (`VISUAL_DRAFT`, `COPY_DRAFT`, `final_assembler`), nos metadados (`visual.reference_assets`) e nos logs estruturados.
+- **Adaptação de expressão**: diretrizes específicas instruem como preservar aparência e variar expressão facial nas três imagens sequenciais, com exemplos antes/depois e verificações automatizadas/QA.
+- **Compatibilidade com agentes**: reiterada a manutenção das instruções determinísticas de `code_generator`, `code_reviewer` e `code_refiner`, destacando que os novos placeholders complementam — mas não substituem — os três prompts obrigatórios.
+- **Rastreabilidade**: todas as lacunas mapeadas na tabela de diagnóstico inicial foram cobertas ao longo das fases 2–4; eventuais pendências futuras devem ser registradas explicitamente nesta seção.
+
+---
 ## Resumo Executivo da Implementação
 1. **Fase 1 (Fundação)**: schemas e cache para metadados de referência.
 2. **Fase 2 (Backend)**: endpoint de upload + `/run_preflight` enriquecido.
@@ -255,3 +308,12 @@
 7. **Fase 7 (Docs/Rollout)**: documentação e estratégia de ativação gradual.
 
 Sequenciar dessa forma evita dependências circulares (schemas e cache devem existir antes de endpoints, que precisam estar prontos antes dos agentes, etc.) e garante rastreabilidade completa para validação automática e implementação por múltiplos times ou agentes.
+
+---
+## Checklist de Aprovação da Atualização
+- [ ] Confirmar presença e preenchimento da tabela "Lacunas de Detalhamento" logo após a Visão Geral.
+- [ ] Verificar que a seção 0 descreve os quatro cenários e a política de uso obrigatório pós-aprovação.
+- [ ] Revisar a Fase 4 para garantir que as diretrizes de expressão facial e preservação de aparência estão documentadas com exemplos.
+- [ ] Validar que os critérios de testes/QA (Fase 6) exigem evidências de mudança de expressão e cobrem reprovação do SafeSearch.
+- [ ] Checar que a seção "Resumo das Atualizações de Prompt" sintetiza os reforços e reitera compatibilidade com os agentes fixos.
+- [ ] Registrar aprovação das lideranças responsáveis antes de executar ajustes no código.

--- a/plano_atualizacao_imagem_roupa.md
+++ b/plano_atualizacao_imagem_roupa.md
@@ -1,0 +1,130 @@
+# Plano de Atualização — Detalhamento de Prompts e Uso de Referências Visuais
+
+## 0. Objetivo Geral
+- **Meta**: Atualizar o documento `imagem_roupa.md` para descrever, com nível operacional, como referências visuais opcionais (personagem e produto) devem ser tratadas, incluindo condicionais nos prompts e critérios para manipulação de expressões faciais.
+- **Escopo**: Somente edição do plano existente (`imagem_roupa.md`). Não envolve alterações de código ou configuração.
+
+---
+## Fase 1 — Levantamento e Diagnóstico do Documento Atual
+
+### Objetivo específico
+Garantir entendimento profundo do estado atual do plano e identificar todas as lacunas narrativas e técnicas relacionadas ao uso de referências visuais, servindo de insumo para as fases posteriores.
+
+### Atividades detalhadas
+1. **Leitura estruturada**: revisar sequencialmente todas as seções de `imagem_roupa.md` (Visão Geral, Fases 1–7, Dependências, Riscos, Apêndices) anotando trechos que mencionem referências visuais, prompts e comportamento opcional.
+2. **Inventário de lacunas**: classificar cada ausência em três categorias – `Opcionalidade`, `Uso obrigatório pós-aprovação` e `Adaptação de expressão/prompt`. Para cada ocorrência, registrar a página/seção afetada e o risco associado.
+3. **Consolidação das evidências**: transformar as anotações em uma tabela "Lacunas de Detalhamento" posicionada após a Visão Geral, contendo colunas: `Seção`, `Descrição da lacuna`, `Impacto esperado`, `Prioridade de correção (Alta/Média/Baixa)`.
+4. **Validação cruzada**: confrontar as lacunas identificadas com os requisitos descritos pelo usuário nesta conversa para assegurar que nenhuma necessidade declarada fique de fora do mapeamento.
+
+### Entregáveis
+- Tabela "Lacunas de Detalhamento" acrescentada ao documento com, no mínimo, uma entrada por categoria de ausência identificada.
+- Registro textual breve anterior à tabela explicando a metodologia de diagnóstico empregada.
+
+### Dependências existentes
+- Conteúdo atual de `imagem_roupa.md` (versão em vigor neste repositório).
+- Observações do usuário (requisitos de opcionalidade e diferenciação de prompts para personagem/produto).
+- `guia_redacao_planos_implementacao.md` para alinhamento de linguagem e estrutura de seções.
+
+### Critérios de aceitação
+- [ ] Tabela de lacunas adicionada próximo ao topo do documento (logo após Visão Geral) para contextualizar ajustes que serão feitos nas fases seguintes.
+- [ ] Cada lacuna está classificada em uma das três categorias e possui indicação de impacto.
+
+---
+## Fase 2 — Atualizações na Visão Geral e Metas
+
+### Objetivo específico
+Reposicionar a introdução do plano para que os stakeholders compreendam, logo no início, os compromissos sobre referências visuais opcionais, usos mandatórios após aprovação e implicações para o pipeline de prompts.
+
+### Atividades detalhadas
+1. **Redação de contexto ampliado**: incluir parágrafo introdutório explicando por que referências opcionais exigem lógica condicional nos agentes e como isso impacta a experiência do anunciante.
+2. **Definição explícita de cenários**: adicionar bullets enumerando os quatro cenários suportados (sem referências, apenas personagem, apenas produto, ambos) descrevendo comportamento esperado em cada um.
+3. **Política de uso obrigatório**: inserir sub-bullet especificando que qualquer referência aprovada pelo SafeSearch deve ser utilizada em todas as etapas pertinentes (prompts, geração visual, montagem final) e que rejeições devem ser registradas/logadas.
+4. **Compromissos de prompt**: destacar, em linguagem prescritiva, a obrigação de diferenciação dos prompts quando `reference_image_character_summary` existir, incluindo menção à preservação de traços físicos e à adaptação de expressão facial conforme instruções do ADK.
+5. **Indicadores de sucesso**: apontar métricas textuais (ex.: "QA deve comprovar que prompts finais mencionam explicitamente a presença do personagem quando disponível") para orientar validações futuras.
+
+### Entregáveis
+- Seção "Visão Geral & Metas" reescrita com os novos parágrafos e bullets descritos nas atividades.
+- Nota lateral ou box de destaque resumindo o fluxo de aprovação via SafeSearch e a obrigatoriedade subsequente de uso.
+
+### Critérios de aceitação
+- [ ] Seção atualizada apresenta requisitos textuais sobre opcionalidade, obrigatoriedade de uso após aprovação e diferenciação de prompts.
+- [ ] Os quatro cenários (0, 1 ou 2 referências) estão descritos com comportamento esperado.
+
+---
+## Fase 3 — Ajustes na Fase 4 (Pipeline & Prompts)
+
+### Objetivo específico
+Determinizar, na própria descrição do pipeline, como os agentes devem consumir dados de referências visuais e como os prompts se adaptam a cada cenário, garantindo que implementadores não precisem interpretar lacunas.
+
+### Atividades detalhadas
+1. **Reorganização estrutural**: dividir a seção "Fase 4 – Pipeline de Agentes" em subtítulos numerados (ex.: "4.1 Placeholders e estrutura de dados", "4.2 Diretrizes de Prompting para Personagem", "4.3 Diretrizes quando apenas Produto estiver presente", "4.4 Compatibilidade com instruções fixas dos agentes").
+2. **Definição de placeholders condicionais**: para cada subtítulo, documentar quais campos devem ser introduzidos nos prompts (`{reference_image_character_summary}`, `{reference_image_product_summary}`, flags booleanas, notas do SafeSearch) e a lógica que ativa cada um (ex.: "incluir somente quando `reference_images.character.status == 'approved'`").
+3. **Guia aprofundado de prompting**: elaborar lista de verificação para `VISUAL_DRAFT`, `COPY_DRAFT` e `final_assembler` contendo:
+   - Frases-modelo que mencionem o personagem pelo nome/descrição quando existir.
+   - Instruções explícitas de preservação de características físicas (tom de pele, cabelo, formato de rosto).
+   - Exigência de comandos que permitam mudar a expressão facial (ex.: "If the ADK prompt requests a different emotion, articulate it as 'render the same character now showing <emoção>'").
+4. **Cenários sem personagem**: definir estrutura condicional para remover instruções sobre personagem, reforçando descrição de produto e storytelling correspondente.
+5. **Não regressão das instruções fixas**: inserir parágrafo garantindo que os campos já estabelecidos para três imagens sequenciais (prompts `prompt_estado_atual`, `prompt_estado_intermediario`, `prompt_estado_aspiracional`) continuam obrigatórios; sugerir nota sobre como novos placeholders convivem com eles sem alterar formato esperado pelos agentes `code_generator`, `code_reviewer`, `code_refiner`.
+6. **Quadro comparativo**: adicionar tabela resumindo diferenças de prompts entre os quatro cenários (nenhum, apenas personagem, apenas produto, ambos) destacando exemplos de frases-chave e objetivos.
+
+### Entregáveis
+- Seção Fase 4 reescrita com subtítulos, tabela comparativa e listas de verificação descritas.
+- Anexo (ou bloco em destaque) com exemplos de prompts antes/depois demonstrando adaptação de expressão facial.
+
+### Critérios de aceitação
+- [ ] Subtópicos adicionados explicam mudanças de expressão facial e preservação de aparência.
+- [ ] Diferenças textuais deixam explícito que ajustes convivem com instruções fixas dos agentes (`code_generator`, `code_reviewer`, `code_refiner`).
+- [ ] Tabela comparativa cobre os quatro cenários possíveis.
+
+---
+## Fase 4 — Critérios de Aceitação e QA
+
+### Objetivo específico
+Assegurar que o plano descreva verificações robustas, tanto automatizadas quanto manuais, capazes de comprovar que prompts e saídas honram os requisitos de referências visuais e adaptação de expressão.
+
+### Atividades detalhadas
+1. **Revisão dos critérios existentes**: localizar na Fase 4 e na Fase 6 de `imagem_roupa.md` todos os bullets de QA atuais e identificar onde adicionar reforços relacionados a referências.
+2. **Ampliação dos testes automatizados**: instruir a criação/atualização de testes unitários e de integração que simulem combinações de referências, incluindo mocks de SafeSearch aprovando/reprovando imagens e asserts sobre a presença de comandos de expressão facial nos prompts.
+3. **Checklist de QA manual**: definir passos concretos (capturar screenshots dos prompts gerados, validar que personagem é citado quando disponível, comprovar mudança de expressão solicitada) e anexar à fase pertinente.
+4. **Evidências esperadas**: solicitar que as equipes documentem exemplos "antes/depois" em artefatos de QA (ex.: pasta `artifacts/qa/reference-images`) para compor baseline visual.
+5. **Cobertura de regressão**: inserir instrução garantindo que os testes mantenham critérios já existentes sobre três imagens sequenciais, assegurando que novos casos não removam asserts prévios.
+
+### Entregáveis
+- Atualização das seções de critérios de aceitação com bullets específicos sobre transformação de expressão, uso condicional de referências e coleta de evidências.
+- Seção QA enriquecida com links ou referências a fixtures/mocks necessários para testes de personagem com expressão divergente.
+
+### Critérios de aceitação
+- [ ] Critérios atualizados descrevem explicitamente cenários de mudança de expressão.
+- [ ] QA manual/documentação passa a exigir captura de exemplos antes/depois quando houver personagem.
+- [ ] Novos testes/mocks descritos não conflitam com os requisitos existentes do pipeline de agentes.
+
+---
+## Fase 5 — Consolidação e Revisão Final
+
+### Objetivo específico
+Finalizar a atualização do plano assegurando consistência editorial, rastreabilidade das mudanças e alinhamento com as instruções permanentes dos agentes.
+
+### Atividades detalhadas
+1. **Seção de síntese**: criar a subseção "Resumo das Atualizações de Prompt" contendo bullets agrupados por tema (`Opcionalidade`, `Uso obrigatório`, `Adaptação de expressão`, `Compatibilidade com agentes`).
+2. **Revisão terminológica**: executar busca por termos divergentes ("imagem de personagem", "foto do personagem", etc.) e unificar nomenclatura em todo o documento; registrar no changelog do plano se houver.
+3. **Cross-check com Fase 1**: verificar se todas as lacunas listadas na tabela inicial receberam solução nas fases 2–4; caso alguma permaneça, descrevê-la como "pendência" ou justificar sua postergação.
+4. **Controle de regressão**: reler as seções que tratam dos agentes `code_generator`, `code_reviewer` e `code_refiner`, confirmando que os reforços determinísticos introduzidos anteriormente foram preservados; incluir nota explícita reiterando que essas instruções permanecem válidas e que os novos ajustes são incrementais.
+5. **Preparação para aprovação**: adicionar checklist final com itens que o revisor deve validar antes de aprovar a atualização (ex.: "confirmar presença da tabela de lacunas", "validar exemplos de prompts com mudança de expressão").
+
+### Entregáveis
+- Seção final adicionada com bullets claros e agrupados por tema.
+- Checklist de aprovação final anexado ao término do documento.
+
+### Critérios de aceitação
+- [ ] Seção-resumo adicionada com bullets claros.
+- [ ] Terminologia harmonizada em todas as fases.
+- [ ] Nota sobre preservação das instruções dos agentes presente quando apropriado.
+- [ ] Todas as lacunas da Fase 1 possuem resolução registrada ou justificativa formal.
+
+---
+## Checklist de Finalização
+- [ ] Todas as novas subseções utilizam linguagem declarativa, alinhada ao `guia_redacao_planos_implementacao.md`.
+- [ ] Diferenças planejadas citam explicitamente que tratam-se de edições no documento `imagem_roupa.md` (sem tocar código).
+- [ ] Plano pronto para validação via `plan-code-validator`, sem introduzir dependências inexistentes.
+- [ ] Documento final responde aos questionamentos do usuário sobre opcionalidade, uso obrigatório após aprovação e adaptação de expressão facial.
+


### PR DESCRIPTION
## Summary
- expandir a seção de visão geral do `imagem_roupa.md` com cenários opcionais, política de uso obrigatório pós-aprovação e tabela de lacunas diagnosticadas
- reestruturar a Fase 4 em subtópicos condicionais com tabela comparativa e exemplo antes/depois para diferenciação de prompts conforme personagens e produtos enviados
- fortalecer critérios de QA e seções finais adicionando requisitos de evidência, resumo das atualizações de prompt e checklist específico para aprovação da revisão

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e41fdedd78832184e6a4899c2efe3e